### PR TITLE
feat: add auto-recovery for Telegram bot service on startup

### DIFF
--- a/src/armactl/bot_manager.py
+++ b/src/armactl/bot_manager.py
@@ -94,6 +94,7 @@ def render_bot_service_unit(instance: str) -> str:
     project_root = Path(__file__).resolve().parents[2]
     templates_dir = project_root / "templates"
     env = Environment(loader=FileSystemLoader(str(templates_dir)))
+    home_dir = Path.home()
     user = os.getenv("USER", "root")
     try:
         if user == "root" and os.getlogin():
@@ -105,6 +106,8 @@ def render_bot_service_unit(instance: str) -> str:
     return service_template.render(
         instance=instance,
         user=user,
+        home_dir=str(home_dir),
+        bot_dir=str(paths.bot_dir(instance)),
         project_root=str(project_root),
         python_bin=str(bot_python_path()),
     )
@@ -180,6 +183,51 @@ def get_bot_service_status() -> dict[str, Any]:
         privileged_channel_installed=has_privileged_systemctl_channel(),
     )
     return status
+
+
+def ensure_bot_service_runtime(instance: str) -> list[ServiceResult]:
+    """Best-effort auto-heal for an already installed and enabled Telegram bot."""
+    try:
+        config = load_bot_config(instance)
+    except Exception as e:
+        return [
+            ServiceResult(
+                False,
+                tr(
+                    "Failed to load Telegram bot settings: {error}",
+                    error=redact_sensitive_text(e),
+                ),
+                1,
+            )
+        ]
+
+    if not config.enabled or not paths.bot_service_file().exists():
+        return []
+
+    runtime_result = check_bot_runtime()
+    if not runtime_result.success:
+        return [runtime_result]
+
+    status = get_service_status(bot_service_name())
+    results: list[ServiceResult] = []
+
+    if not status.get("enabled"):
+        enable_result = enable_service(bot_service_name())
+        results.append(enable_result)
+        if not enable_result.success:
+            return results
+        status["enabled"] = True
+
+    active_state = str(status.get("active_state", "")).lower()
+    is_running = bool(status.get("active")) or active_state in {
+        "active",
+        "activating",
+        "reloading",
+    }
+    if not is_running:
+        results.append(start_bot_service())
+
+    return results
 
 
 def start_bot_service() -> ServiceResult:

--- a/src/armactl/locales/uk.json
+++ b/src/armactl/locales/uk.json
@@ -125,6 +125,8 @@
     "Bot service and secure control channel installed/updated.": "Сервіс бота та захищений канал керування встановлено/оновлено.",
     "Bot service applied and bot runtime is ready.": "Сервіс бота застосовано, а runtime бота готовий.",
     "Refreshed bot service status.": "Стан сервісу бота оновлено.",
+    "Recovered Telegram bot service automatically after host boot.": "Telegram-бота автоматично відновлено після перезавантаження хоста.",
+    "Telegram bot auto-start check failed: {error}": "Перевірка автозапуску Telegram-бота не вдалася: {error}",
     "Telegram bot must be enabled before installing the bot service.": "Перед встановленням сервісу потрібно увімкнути Telegram-бота.",
     "Bot runtime is ready.": "Середовище бота готове.",
     "Bot runtime Python not found at {path}. Re-run ./scripts/bootstrap.sh --prod or --dev.": "Python для бота не знайдено за шляхом {path}. Повторно виконайте ./scripts/bootstrap.sh --prod або --dev.",

--- a/src/armactl/tui/app.py
+++ b/src/armactl/tui/app.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import os
 import sys
 
+from textual import work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import VerticalGroup
 from textual.widgets import Button, Footer, Header, Label
 
 from armactl import paths
+from armactl.bot_manager import ensure_bot_service_runtime
 from armactl.discovery import discover
 from armactl.i18n import _, get_current_lang_name, toggle_lang, tr
 
@@ -200,6 +202,33 @@ class ArmaCtlApp(App):
     def __init__(self, instance: str = paths.DEFAULT_INSTANCE_NAME, **kwargs):
         super().__init__(**kwargs)
         self.instance = instance
+
+    def on_mount(self) -> None:
+        """Kick off small background health checks once the main menu is shown."""
+        self.ensure_bot_runtime_task()
+
+    @work(exclusive=True, thread=True)
+    def ensure_bot_runtime_task(self) -> None:
+        """Auto-heal the optional Telegram bot when it was already installed earlier."""
+        results = ensure_bot_service_runtime(self.instance)
+        if not results:
+            return
+
+        failures = [result.message for result in results if not result.success]
+        if failures:
+            self.call_from_thread(
+                self.notify,
+                tr("Telegram bot auto-start check failed: {error}", error=failures[0]),
+                title=_("Telegram Bot"),
+                severity="warning",
+            )
+            return
+
+        self.call_from_thread(
+            self.notify,
+            _("Recovered Telegram bot service automatically after host boot."),
+            title=_("Telegram Bot"),
+        )
 
     def compose(self) -> ComposeResult:
         """Create child widgets for the app."""

--- a/templates/armactl-bot.service.j2
+++ b/templates/armactl-bot.service.j2
@@ -2,14 +2,18 @@
 Description=armactl Telegram Bot ({{ instance }})
 After=network-online.target
 Wants=network-online.target
+RequiresMountsFor={{ project_root }} {{ bot_dir }}
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 User={{ user }}
 WorkingDirectory={{ project_root }}
 ExecStart={{ python_bin }} -m armactl.telegram_bot --instance {{ instance }}
-Restart=on-failure
-RestartSec=5
+Restart=always
+RestartSec=15
+Environment=HOME={{ home_dir }}
+Environment=USER={{ user }}
 Environment=PYTHONUNBUFFERED=1
 
 [Install]

--- a/tests/test_bot_manager.py
+++ b/tests/test_bot_manager.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 from armactl.bot_config import BotConfig
 from armactl.bot_manager import (
     check_bot_runtime,
+    ensure_bot_service_runtime,
     get_bot_service_status,
     render_bot_service_unit,
     validate_bot_service_config,
@@ -53,6 +54,77 @@ def test_render_bot_service_unit_contains_instance_and_execstart(tmp_path: Path)
 
     assert "Description=armactl Telegram Bot (default)" in text
     assert f"ExecStart={python_bin} -m armactl.telegram_bot --instance default" in text
+    assert "Restart=always" in text
+    assert "StartLimitIntervalSec=0" in text
+    assert "Environment=HOME=" in text
+
+
+def test_ensure_bot_service_runtime_enables_and_starts_installed_bot(
+    tmp_path: Path,
+) -> None:
+    config = BotConfig(
+        instance="default",
+        enabled=True,
+        token="123456:ABCDEF",
+        admin_chat_ids=["123456789"],
+        language="uk",
+    )
+    service_path = tmp_path / "armactl-bot.service"
+    service_path.write_text("[Unit]\n", encoding="utf-8")
+
+    with (
+        patch("armactl.bot_manager.load_bot_config", return_value=config),
+        patch("armactl.bot_manager.paths.bot_service_file", return_value=service_path),
+        patch(
+            "armactl.bot_manager.check_bot_runtime",
+            return_value=ServiceResult(True, _("Bot runtime is ready.")),
+        ),
+        patch(
+            "armactl.bot_manager.get_service_status",
+            return_value={"active": False, "enabled": False, "active_state": "inactive"},
+        ),
+        patch(
+            "armactl.bot_manager.enable_service",
+            return_value=ServiceResult(
+                True,
+                _("Systemctl action: enable armactl-bot.service: ok"),
+            ),
+        ) as enable_mock,
+        patch(
+            "armactl.bot_manager.start_bot_service",
+            return_value=ServiceResult(
+                True,
+                _("Systemctl action: start armactl-bot.service: ok"),
+            ),
+        ) as start_mock,
+    ):
+        results = ensure_bot_service_runtime("default")
+
+    assert [result.success for result in results] == [True, True]
+    enable_mock.assert_called_once()
+    start_mock.assert_called_once()
+
+
+def test_ensure_bot_service_runtime_ignores_disabled_bot(tmp_path: Path) -> None:
+    config = BotConfig(
+        instance="default",
+        enabled=False,
+        token="",
+        admin_chat_ids=[],
+        language="uk",
+    )
+    service_path = tmp_path / "armactl-bot.service"
+    service_path.write_text("[Unit]\n", encoding="utf-8")
+
+    with (
+        patch("armactl.bot_manager.load_bot_config", return_value=config),
+        patch("armactl.bot_manager.paths.bot_service_file", return_value=service_path),
+        patch("armactl.bot_manager.start_bot_service") as start_mock,
+    ):
+        results = ensure_bot_service_runtime("default")
+
+    assert results == []
+    start_mock.assert_not_called()
 
 
 def test_get_bot_service_status_reports_privileged_channel(tmp_path: Path):


### PR DESCRIPTION
Implement automatic service healing when the TUI app mounts. The new `ensure_bot_service_runtime` function checks if the Telegram bot service is installed, enabled, and running — and recovers it if needed after host reboots. This ensures the bot stays available without manual intervention. Added Ukrainian translations for recovery-related messages.

## Summary

- What changed?
- Why was this needed?

## Validation

- [ ] `./scripts/run-host-tests`
- [ ] Relevant manual flow tested

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [x] systemd / timer
- [ ] config.json handling
- [x] Telegram bot
- [ ] docs only

## Notes

- List any migration, rollback, or operator-facing implications.

