### PR TITLE
Fix sudo helper user detection for bot installs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -84,6 +84,10 @@ installed, rerun:
 This reinstalls the narrow helper and sudoers drop-in used for non-interactive
 service actions.
 
+If the problem started after running install/repair from a root shell, rerun it
+from the regular Linux account that owns the instance so the sudoers rule is
+generated for the correct user.
+
 ## Metrics show as Unknown
 
 Runtime metrics can be unavailable when:

--- a/src/armactl/bot_manager.py
+++ b/src/armactl/bot_manager.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import subprocess
 import tempfile
 from pathlib import Path
@@ -23,6 +22,7 @@ from armactl.service_manager import (
     has_privileged_systemctl_channel,
     install_privileged_systemctl_channel,
     install_systemd_unit_file,
+    resolve_linux_user,
     restart_service,
     start_service,
     stop_service,
@@ -95,12 +95,7 @@ def render_bot_service_unit(instance: str) -> str:
     templates_dir = project_root / "templates"
     env = Environment(loader=FileSystemLoader(str(templates_dir)))
     home_dir = Path.home()
-    user = os.getenv("USER", "root")
-    try:
-        if user == "root" and os.getlogin():
-            user = os.getlogin()
-    except OSError:
-        pass
+    user = resolve_linux_user()
 
     service_template = env.get_template("armactl-bot.service.j2")
     return service_template.render(

--- a/src/armactl/locales/uk.json
+++ b/src/armactl/locales/uk.json
@@ -372,7 +372,7 @@
     "{action} {service_name}: timed out after 30s": "{service_name}: дія \"{action}\" перевищила тайм-аут 30 с",
     "systemctl not found - is systemd installed?": "systemctl не знайдено. Чи встановлено systemd?",
     "{action} {service_name}: {error}": "{service_name}: дія \"{action}\" завершилася помилкою: {error}",
-    "Secure privileged control is not configured yet. Install/update the bot service or re-run install/repair from the TUI to install the secure sudo helper.": "Захищений привілейований канал ще не налаштовано. Встановіть/оновіть сервіс бота або повторно запустіть install/repair з TUI, щоб встановити безпечний sudo-helper.",
+    "Secure privileged control is not configured for this Linux user yet. Install/update the bot service or re-run install/repair from the TUI to refresh the secure sudo helper.": "Захищений привілейований канал ще не налаштовано для цього Linux-користувача. Встановіть/оновіть сервіс бота або повторно запустіть install/repair з TUI, щоб перевстановити безпечний sudo-helper.",
     "Templates directory not found at {path}": "Директорію шаблонів не знайдено за шляхом {path}",
     "Generated {path}": "Згенеровано {path}",
     "Failed to install {name}: {error}": "Не вдалося встановити {name}: {error}",

--- a/src/armactl/service_manager.py
+++ b/src/armactl/service_manager.py
@@ -6,13 +6,13 @@ All systemctl calls go through subprocess with proper error handling.
 
 from __future__ import annotations
 
+import getpass
 import os
 import re
 import shutil
 import subprocess
 import sys
 import tempfile
-import getpass
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any

--- a/src/armactl/service_manager.py
+++ b/src/armactl/service_manager.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import getpass
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -40,6 +41,15 @@ class ServiceResult:
 
     def to_dict(self) -> dict[str, Any]:
         return {"success": self.success, "message": self.message, "exit_code": self.exit_code}
+
+
+def _secure_privileged_channel_message() -> str:
+    """Return the user-facing guidance for missing or stale sudo-helper access."""
+    return _(
+        "Secure privileged control is not configured for this Linux user yet. "
+        "Install/update the bot service or re-run install/repair from the TUI "
+        "to refresh the secure sudo helper."
+    )
 
 
 def _run_systemctl(
@@ -80,11 +90,7 @@ def _run_systemctl(
             if use_sudo and _looks_like_sudo_auth_error(stderr):
                 return ServiceResult(
                     success=False,
-                    message=_(
-                        "Secure privileged control is not configured yet. "
-                        "Install/update the bot service or re-run install/repair "
-                        "from the TUI to install the secure sudo helper."
-                    ),
+                    message=_secure_privileged_channel_message(),
                     exit_code=result.returncode,
                 )
             return ServiceResult(
@@ -185,13 +191,36 @@ def _build_systemctl_command(
 
 def _systemctl_helper_user() -> str:
     """Best-effort current Linux username for helper/sudoers installation."""
-    user = os.getenv("USER", "root")
+    return resolve_linux_user()
+
+
+def resolve_linux_user(default: str = "root") -> str:
+    """Resolve the non-root Linux user armactl should target for services/helpers."""
+    sudo_user = (os.getenv("SUDO_USER") or "").strip()
+    if sudo_user and sudo_user != "root":
+        return sudo_user
+
     try:
-        if user == "root" and os.getlogin():
-            user = os.getlogin()
+        login_user = (os.getlogin() or "").strip()
     except OSError:
-        pass
-    return user
+        login_user = ""
+
+    env_logname = (os.getenv("LOGNAME") or "").strip()
+    env_user = (os.getenv("USER") or "").strip()
+    try:
+        getpass_user = (getpass.getuser() or "").strip()
+    except Exception:
+        getpass_user = ""
+
+    for candidate in (login_user, env_logname, env_user, getpass_user):
+        if candidate and candidate != "root":
+            return candidate
+
+    for candidate in (login_user, env_user, env_logname, getpass_user):
+        if candidate:
+            return candidate
+
+    return default
 
 
 def _templates_dir() -> Path:
@@ -381,11 +410,7 @@ def install_systemd_unit_file(source: Path, destination: Path) -> ServiceResult:
     if _looks_like_sudo_auth_error(stderr):
         return ServiceResult(
             False,
-            _(
-                "Secure privileged control is not configured yet. "
-                "Install/update the bot service or re-run install/repair "
-                "from the TUI to install the secure sudo helper."
-            ),
+            _secure_privileged_channel_message(),
             result.returncode,
         )
 
@@ -437,11 +462,7 @@ def update_restart_timer_schedule(
                     return [
                         ServiceResult(
                             False,
-                            _(
-                                "Secure privileged control is not configured yet. "
-                                "Install/update the bot service or re-run install/repair "
-                                "from the TUI to install the secure sudo helper."
-                            ),
+                            _secure_privileged_channel_message(),
                             update_result.returncode,
                         )
                     ]
@@ -855,12 +876,7 @@ def generate_services(
     results = []
 
     # 1. Paths and Variables
-    user = os.getenv("USER", "root")
-    try:
-        if user == "root" and os.getlogin():
-            user = os.getlogin()
-    except OSError:
-        pass
+    user = resolve_linux_user()
 
     inst_root = paths.instance_root(instance)
 
@@ -971,4 +987,3 @@ def generate_services(
         )
 
     return results
-

--- a/tests/test_bot_manager.py
+++ b/tests/test_bot_manager.py
@@ -49,10 +49,14 @@ def test_check_bot_runtime_reports_missing_python(tmp_path: Path):
 def test_render_bot_service_unit_contains_instance_and_execstart(tmp_path: Path):
     python_bin = tmp_path / ".venv" / "bin" / "python"
 
-    with patch("armactl.bot_manager.bot_python_path", return_value=python_bin):
+    with (
+        patch("armactl.bot_manager.bot_python_path", return_value=python_bin),
+        patch("armactl.bot_manager.resolve_linux_user", return_value="defenders88"),
+    ):
         text = render_bot_service_unit("default")
 
     assert "Description=armactl Telegram Bot (default)" in text
+    assert "User=defenders88" in text
     assert f"ExecStart={python_bin} -m armactl.telegram_bot --instance default" in text
     assert "Restart=always" in text
     assert "StartLimitIntervalSec=0" in text

--- a/tests/test_service_manager.py
+++ b/tests/test_service_manager.py
@@ -10,12 +10,14 @@ from armactl.service_manager import (
     _build_systemctl_command,
     _render_privileged_helper_script,
     _run_systemctl,
+    _secure_privileged_channel_message,
     format_schedule_for_input,
     get_service_status,
     get_timer_status,
     has_privileged_systemctl_channel,
     normalize_on_calendar,
     normalize_on_calendar_entries,
+    resolve_linux_user,
     service_unit_name,
     timer_unit_name,
     update_restart_timer_schedule,
@@ -178,6 +180,28 @@ def test_has_privileged_systemctl_channel_requires_helper_and_sudoers(tmp_path: 
         assert has_privileged_systemctl_channel() is True
 
 
+def test_resolve_linux_user_prefers_sudo_user() -> None:
+    with (
+        patch.dict(
+            "os.environ",
+            {"SUDO_USER": "defenders88", "USER": "root", "LOGNAME": "root"},
+            clear=True,
+        ),
+        patch("armactl.service_manager.os.getlogin", side_effect=OSError),
+        patch("armactl.service_manager.getpass.getuser", return_value="root"),
+    ):
+        assert resolve_linux_user() == "defenders88"
+
+
+def test_resolve_linux_user_falls_back_to_root_when_needed() -> None:
+    with (
+        patch.dict("os.environ", {"USER": "root", "LOGNAME": "root"}, clear=True),
+        patch("armactl.service_manager.os.getlogin", side_effect=OSError),
+        patch("armactl.service_manager.getpass.getuser", return_value="root"),
+    ):
+        assert resolve_linux_user() == "root"
+
+
 def test_render_privileged_helper_script_uses_python_and_lf_newlines() -> None:
     rendered = _render_privileged_helper_script()
 
@@ -286,11 +310,7 @@ def test_run_systemctl_rewrites_noninteractive_sudo_error() -> None:
         result = _run_systemctl("stop", "armareforger.service")
 
     assert result.success is False
-    assert _(
-        "Secure privileged control is not configured yet. "
-        "Install/update the bot service or re-run install/repair "
-        "from the TUI to install the secure sudo helper."
-    ) == result.message
+    assert _secure_privileged_channel_message() == result.message
 
 
 def test_run_systemctl_redacts_secret_values_in_stderr() -> None:

--- a/tests/test_service_manager.py
+++ b/tests/test_service_manager.py
@@ -5,7 +5,6 @@ from subprocess import CompletedProcess
 from unittest.mock import patch
 
 from armactl import paths
-from armactl.i18n import _
 from armactl.service_manager import (
     _build_systemctl_command,
     _render_privileged_helper_script,


### PR DESCRIPTION
## Summary

- What changed?
- Why was this needed?

## Validation

- [ ] `./scripts/run-host-tests`
- [x] Relevant manual flow tested

## Risk areas

- [x] Install / bootstrap
- [ ] Existing server detection
- [x] systemd / timer
- [ ] config.json handling
- [x] Telegram bot
- [ ] docs only

## Notes

- List any migration, rollback, or operator-facing implications.

