### PR TITLE
refactor: update sudoers naming and helper matching logic

### DIFF
--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -34,7 +34,7 @@ Current status:
   schedule actions through the existing armactl backend
 - Privileged service control is performed through a narrowly-scoped helper
   installed to `/usr/local/libexec/armactl-systemctl-helper` and authorized via
-  `/etc/sudoers.d/armactl-systemctl-helper.sudoers`
+  `/etc/sudoers.d/armactl-systemctl-helper`
 - Timer schedule updates use the same helper, but only through a dedicated
   narrow path that rewrites the allowed restart timer file instead of allowing
   arbitrary unit installation

--- a/src/armactl/bot_manager.py
+++ b/src/armactl/bot_manager.py
@@ -175,6 +175,11 @@ def get_bot_service_status() -> dict[str, Any]:
     service_user = str(status.get("user", "")).strip()
     helper_user = get_privileged_channel_user()
     current_user = resolve_linux_user()
+    helper_matches_service_user: bool | None
+    if service_user and helper_user:
+        helper_matches_service_user = service_user == helper_user
+    else:
+        helper_matches_service_user = None
     status.update(
         service_file=str(paths.bot_service_file()),
         installed=paths.bot_service_file().exists(),
@@ -183,9 +188,8 @@ def get_bot_service_status() -> dict[str, Any]:
         service_user=service_user,
         current_linux_user=current_user,
         privileged_channel_user=helper_user,
-        privileged_channel_matches_service_user=(
-            bool(service_user and helper_user and service_user == helper_user)
-        ),
+        privileged_channel_user_known=helper_user is not None,
+        privileged_channel_matches_service_user=helper_matches_service_user,
     )
     return status
 

--- a/src/armactl/paths.py
+++ b/src/armactl/paths.py
@@ -26,7 +26,7 @@ RESTART_SERVICE_NAME = "armareforger-restart.service"
 TIMER_NAME = "armareforger-restart.timer"
 BOT_SERVICE_NAME = "armactl-bot.service"
 PRIVILEGED_HELPER_NAME = "armactl-systemctl-helper"
-PRIVILEGED_SUDOERS_NAME = "armactl-systemctl-helper.sudoers"
+PRIVILEGED_SUDOERS_NAME = "armactl-systemctl-helper"
 
 
 # ---------------------------------------------------------------------------

--- a/src/armactl/service_manager.py
+++ b/src/armactl/service_manager.py
@@ -291,7 +291,7 @@ def install_privileged_systemctl_channel() -> list[ServiceResult]:
         with tempfile.TemporaryDirectory() as tempd:
             temp_dir = Path(tempd)
             helper_temp = temp_dir / paths.PRIVILEGED_HELPER_NAME
-            sudoers_temp = temp_dir / paths.PRIVILEGED_SUDOERS_NAME
+            sudoers_temp = temp_dir / f"{paths.PRIVILEGED_HELPER_NAME}.sudoers"
             helper_temp.write_text(helper_text, encoding="utf-8")
             sudoers_temp.write_text(sudoers_text, encoding="utf-8")
 

--- a/src/armactl/tui/screens.py
+++ b/src/armactl/tui/screens.py
@@ -1119,11 +1119,13 @@ class BotConfigScreen(Screen):
             helper_user = bot_service.get("privileged_channel_user") or _("Unknown")
             service_user = bot_service.get("service_user") or _("Unknown")
             current_linux_user = bot_service.get("current_linux_user") or _("Unknown")
-            helper_matches = (
-                _("Yes")
-                if bot_service.get("privileged_channel_matches_service_user")
-                else _("No")
-            )
+            helper_match_value = bot_service.get("privileged_channel_matches_service_user")
+            if helper_match_value is True:
+                helper_matches = _("Yes")
+            elif helper_match_value is False:
+                helper_matches = _("No")
+            else:
+                helper_matches = _("Unknown")
 
             lines.extend(
                 [
@@ -1163,9 +1165,7 @@ class BotConfigScreen(Screen):
             description = str(bot_service.get("description", "")).strip()
             if description:
                 lines.append(tr("Bot service description: {value}", value=description))
-            if bot_service.get("privileged_channel_installed") and not bot_service.get(
-                "privileged_channel_matches_service_user"
-            ):
+            if bot_service.get("privileged_channel_matches_service_user") is False:
                 lines.append(
                     _(
                         "[bold yellow]Secure control channel is currently granted "
@@ -2092,4 +2092,3 @@ class ModManagerScreen(Screen):
             )
             if count > 0:
                 self.action_refresh_mods()
-

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -98,7 +98,7 @@ def test_privileged_helper_file():
 
 def test_privileged_sudoers_file():
     path = privileged_sudoers_file()
-    assert path == Path("/etc/sudoers.d") / "armactl-systemctl-helper.sudoers"
+    assert path == Path("/etc/sudoers.d") / "armactl-systemctl-helper"
 
 
 def test_privileged_helper_and_sudoers_paths_are_distinct():

--- a/tests/test_service_manager.py
+++ b/tests/test_service_manager.py
@@ -168,8 +168,10 @@ def test_get_service_status_keeps_zero_memory_current() -> None:
 
 
 def test_has_privileged_systemctl_channel_requires_helper_and_sudoers(tmp_path: Path) -> None:
-    helper_path = tmp_path / "armactl-systemctl-helper"
-    sudoers_path = tmp_path / "armactl-systemctl-helper.sudoers"
+    helper_path = tmp_path / "libexec" / "armactl-systemctl-helper"
+    sudoers_path = tmp_path / "sudoers.d" / "armactl-systemctl-helper"
+    helper_path.parent.mkdir()
+    sudoers_path.parent.mkdir()
 
     with (
         patch("armactl.service_manager.paths.privileged_helper_file", return_value=helper_path),
@@ -183,7 +185,8 @@ def test_has_privileged_systemctl_channel_requires_helper_and_sudoers(tmp_path: 
 
 
 def test_get_privileged_channel_user_parses_sudoers_dropin(tmp_path: Path) -> None:
-    sudoers_path = tmp_path / "armactl-systemctl-helper.sudoers"
+    sudoers_path = tmp_path / "sudoers.d" / "armactl-systemctl-helper"
+    sudoers_path.parent.mkdir()
     sudoers_path.write_text(
         "defenders88 ALL=(root) NOPASSWD: /usr/local/libexec/armactl-systemctl-helper, "
         "/usr/local/libexec/armactl-systemctl-helper *\n",


### PR DESCRIPTION
- Remove .sudoers extension from PRIVILEGED_SUDOERS_NAME constant
- Adjust file creation in service manager to use updated naming convention
- Change bot service status to use three-state matching (True/False/Unknown)
- Update UI to display "Unknown" when helper user or service user unavailable
- Only show warning when helper user definitely does not match service user

## Summary

- What changed?
- Why was this needed?

## Validation

- [ ] `./scripts/run-host-tests`
- [ ] Relevant manual flow tested

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [x] systemd / timer
- [ ] config.json handling
- [x] Telegram bot
- [ ] docs only

## Notes

- List any migration, rollback, or operator-facing implications.

