### PR TITLE
chore: sync version metadata after v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ Semantic Versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.1.3]
+
+### Fixed
+- Synchronized in-repo version metadata after the `v0.1.2` release.
+- Updated release-process examples to use generic semantic version tags.
+- Cleaned up the package version module header text.
+
+## [0.1.2]
+
+### Fixed
+- Corrected the privileged sudoers drop-in naming so Telegram bot control and
+  schedule actions work without prompting for a password after reinstalling the
+  bot service.
+- Improved privileged helper diagnostics for mismatched Linux users between the
+  bot service and the secure control channel.
+- Hardened privileged-channel detection when sudoers files are unreadable.
+- Updated Telegram bot troubleshooting and helper-related documentation.
+
 ## [0.1.1]
 
 ### Fixed

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -25,8 +25,8 @@ Ship a GitHub Release that matches the repo-local operational model of
 Use semantic version tags:
 
 ```bash
-git tag v0.1.0
-git push origin v0.1.0
+git tag vX.Y.Z
+git push origin vX.Y.Z
 ```
 
 ## Release workflow
@@ -42,4 +42,3 @@ The GitHub release workflow should:
 - Verify installation from the release archive
 - Verify `./armactl` on another machine
 - Check release notes and attached artifacts
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "armactl"
-version = "0.1.1"
+version = "0.1.3"
 description = "Installer, manager and TUI for Arma Reforger Dedicated Server on Linux"
 readme = "README.md"
 license = "MIT"

--- a/src/armactl/__init__.py
+++ b/src/armactl/__init__.py
@@ -1,3 +1,3 @@
-"""armactl — installer, manager and TUI for Arma Reforger Dedicated Server."""
+"""armactl - installer, manager and TUI for Arma Reforger Dedicated Server."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.3"


### PR DESCRIPTION
## Summary

- What changed?
- Why was this needed?

## Validation

- [ ] `./scripts/run-host-tests`
- [ ] Relevant manual flow tested

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [ ] systemd / timer
- [ ] config.json handling
- [ ] Telegram bot
- [x] docs only

## Notes

- List any migration, rollback, or operator-facing implications.

