### PR TITLE
fix(tui): use display label in TailLogScreen title

### DIFF
--- a/src/armactl/tui/screens.py
+++ b/src/armactl/tui/screens.py
@@ -367,7 +367,10 @@ class TailLogScreen(Screen):
     def compose(self) -> ComposeResult:
         yield Header()
         yield Label(
-            tr("Live Logs: {instance} (Press Q to exit)", instance=self.instance),
+            tr(
+                "Live Logs: {instance} (Press Q to exit)",
+                instance=get_instance_display_label(self.instance),
+            ),
             id="screen-title",
         )
         yield RichLog(id="tail-log", highlight=True, markup=False)


### PR DESCRIPTION
## Summary

- Applied `get_instance_display_label()` to the TailLogScreen header.
- This keeps server display naming consistent across the TUI by showing the public server name together with the technical instance id.

## Related issue

Closes #

## Validation

- [x] `./scripts/run-host-tests`
- [x] `python3 -m pytest -q`
- [x] `python3 -m ruff check src tests`
- [x] Relevant manual flow tested
- [x] TUI flow tested, if this PR changes Textual screens or user interaction
- [x] The changed files are relevant to the linked issue
- [x] This PR does not introduce unrelated changes

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [ ] systemd / timer
- [ ] config.json handling
- [ ] Mods / addon cleanup
- [x] TUI / UX / Textual screens
- [ ] Telegram bot
- [ ] Release / versioning
- [ ] docs only

## Automated contribution disclosure

- [x] This PR was written or substantially reviewed by a human maintainer/contributor
- [x] This is not a low-effort automated bounty submission
- [x] If AI or automation was used, the generated changes were manually reviewed

## Notes

- No migration or rollback required.
- Operator-facing impact: the live logs screen now uses the same server display label format as the rest of the TUI.