### PR TITLE
fix(tui): refresh main menu after install and repair

### DIFF
--- a/src/armactl/locales/uk.json
+++ b/src/armactl/locales/uk.json
@@ -18,6 +18,7 @@
     "Installing Server -> {instance}": "Встановлення сервера -> {instance}",
     "Repairing Server -> {instance}": "Відновлення сервера -> {instance}",
     "Server files detected! Restart app to see Manage screen.": "Файли сервера знайдено! Перезапустіть застосунок, щоб побачити екран керування.",
+    "Server files detected. Main menu updated.": "Файли сервера знайдено. Головне меню оновлено.",
     "No server installation found at default paths.": "За типовими шляхами встановлення сервера не знайдено.",
     "Incomplete server installation detected. Use Repair Installation to finish validation.": "Виявлено неповне встановлення сервера. Скористайтеся «Відновити встановлення», щоб завершити перевірку.",
     "Success": "Успіх",

--- a/src/armactl/tui/app.py
+++ b/src/armactl/tui/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+from asyncio import Lock
 from dataclasses import dataclass
 from typing import Literal
 
@@ -266,6 +267,7 @@ class ArmaCtlApp(App):
         super().__init__(**kwargs)
         self.instance = instance
         self._main_menu: VerticalGroup | None = None
+        self._main_menu_refresh_lock = Lock()
 
     def on_mount(self) -> None:
         """Kick off small background health checks once the main menu is shown."""
@@ -363,14 +365,15 @@ class ArmaCtlApp(App):
 
     async def refresh_main_menu(self, *, save: bool = False) -> ServerState:
         """Re-run discovery and rebuild the root menu without duplicate widget IDs."""
-        state = discover(instance=self.instance, save=save)
-        if self._main_menu is None:
-            return state
+        async with self._main_menu_refresh_lock:
+            state = discover(instance=self.instance, save=save)
+            if self._main_menu is None:
+                return state
 
-        async with self._main_menu.batch():
-            await self._main_menu.remove_children()
-            await self._main_menu.mount_all(self._main_menu_widgets(state))
-        return state
+            async with self._main_menu.batch():
+                await self._main_menu.remove_children()
+                await self._main_menu.mount_all(self._main_menu_widgets(state))
+            return state
 
     def request_main_menu_refresh(self, *, save: bool = False) -> None:
         """Schedule a root menu refresh from sync or worker callbacks."""

--- a/src/armactl/tui/app.py
+++ b/src/armactl/tui/app.py
@@ -4,18 +4,56 @@ from __future__ import annotations
 
 import os
 import sys
+from dataclasses import dataclass
+from typing import Literal
 
 from textual import work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import VerticalGroup
+from textual.widget import Widget
 from textual.widgets import Button, Footer, Header, Label
 
 from armactl import paths
 from armactl.bot_manager import ensure_bot_service_runtime
 from armactl.discovery import discover
 from armactl.i18n import _, get_current_lang_name, toggle_lang, tr
+from armactl.state import ServerState
 from armactl.tui.display import get_instance_server_name
+
+MainMenuWidgetKind = Literal["button", "status", "warning"]
+
+
+@dataclass(frozen=True)
+class MainMenuEntry:
+    """Pure description of a main menu row."""
+
+    kind: MainMenuWidgetKind
+    widget_id: str
+    variant: str | None = None
+
+
+def build_main_menu_entries(state: ServerState) -> tuple[MainMenuEntry, ...]:
+    """Return the state-dependent main menu entries."""
+    entries: list[MainMenuEntry] = [MainMenuEntry("status", "main-menu-status")]
+
+    if state.server_installed:
+        entries.append(MainMenuEntry("button", "btn_manage", "primary"))
+    else:
+        if state.has_install_evidence():
+            entries.append(MainMenuEntry("warning", "install-warning"))
+        entries.append(MainMenuEntry("button", "btn_install", "success"))
+
+    entries.extend(
+        [
+            MainMenuEntry("button", "btn_repair", "warning"),
+            MainMenuEntry("button", "btn_detect", "default"),
+            MainMenuEntry("button", "btn_host_tests", "primary"),
+            MainMenuEntry("button", "btn_lang", "default"),
+            MainMenuEntry("button", "btn_exit", "error"),
+        ]
+    )
+    return tuple(entries)
 
 
 def _restore_terminal_state() -> None:
@@ -67,7 +105,8 @@ class ArmaCtlApp(App):
         align: center middle;
     }
     #main-menu, #manage-container, #confirm-dialog {
-        width: 50;
+        width: 64;
+        max-width: 90%;
         height: auto;
         border: solid green;
         padding: 1 2;
@@ -169,6 +208,14 @@ class ArmaCtlApp(App):
         margin-bottom: 1;
         color: $text-muted;
     }
+    #main-menu-status, #install-warning {
+        width: 100%;
+        content-align: center middle;
+        margin-bottom: 1;
+    }
+    #install-warning {
+        color: yellow;
+    }
     #mods-list {
         height: 1fr;
         border: solid green;
@@ -218,6 +265,7 @@ class ArmaCtlApp(App):
     def __init__(self, instance: str = paths.DEFAULT_INSTANCE_NAME, **kwargs):
         super().__init__(**kwargs)
         self.instance = instance
+        self._main_menu: VerticalGroup | None = None
 
     def on_mount(self) -> None:
         """Kick off small background health checks once the main menu is shown."""
@@ -246,48 +294,113 @@ class ArmaCtlApp(App):
             title=_("Telegram Bot"),
         )
 
-    def compose(self) -> ComposeResult:
-        """Create child widgets for the app."""
-        yield Header(show_clock=True)
-        with VerticalGroup(id="main-menu"):
-            server_name = get_instance_server_name(self.instance)
-            yield Label(_("Arma Reforger Manager"), id="title")
-            yield Label(server_name or self.instance, id="instance-server-name")
-            if server_name:
-                yield Label(tr("Instance: {instance}", instance=self.instance), id="instance-id")
+    def _main_menu_widgets(self, state: ServerState) -> list[Widget]:
+        """Build fresh widgets for the root menu."""
+        server_name = get_instance_server_name(self.instance)
+        widgets: list[Widget] = [
+            Label(_("Arma Reforger Manager"), id="title"),
+            Label(server_name or self.instance, id="instance-server-name"),
+        ]
+        if server_name:
+            widgets.append(
+                Label(
+                    tr("Instance: {instance}", instance=self.instance),
+                    id="instance-id",
+                )
+            )
 
-            state = discover(instance=self.instance, save=False)
-            if state.server_installed:
-                yield Button(_("Manage Existing Server >>"), id="btn_manage", variant="primary")
-            else:
-                if state.has_install_evidence():
-                    yield Label(
+        installed_text = _("Yes") if state.server_installed else _("No")
+        widgets.append(
+            Label(
+                tr("Installed: {value}", value=installed_text),
+                id="main-menu-status",
+            )
+        )
+
+        for entry in build_main_menu_entries(state):
+            if entry.kind == "status":
+                continue
+
+            if entry.kind == "warning":
+                widgets.append(
+                    Label(
                         _(
                             "Incomplete server installation detected. "
                             "Use Repair Installation to finish validation."
                         ),
-                        id="install-warning",
+                        id=entry.widget_id,
                     )
-                yield Button(_("Install New Server"), id="btn_install", variant="success")
+                )
+                continue
 
-            yield Button(_("Repair Installation"), id="btn_repair", variant="warning")
-            yield Button(_("Detect Existing Server"), id="btn_detect", variant="default")
-            yield Button(_("Run Host Tests"), id="btn_host_tests", variant="primary")
-            lang_label = _("Language:") + f" {get_current_lang_name()}"
-            yield Button(lang_label, id="btn_lang", variant="default")
-            yield Button(_("Exit"), id="btn_exit", variant="error")
+            widgets.append(
+                Button(
+                    self._main_menu_button_label(entry.widget_id),
+                    id=entry.widget_id,
+                    variant=entry.variant or "default",
+                )
+            )
+
+        return widgets
+
+    def _main_menu_button_label(self, widget_id: str) -> str:
+        """Return the current label for a main menu button."""
+        if widget_id == "btn_manage":
+            return _("Manage Existing Server >>")
+        if widget_id == "btn_install":
+            return _("Install New Server")
+        if widget_id == "btn_repair":
+            return _("Repair Installation")
+        if widget_id == "btn_detect":
+            return _("Detect Existing Server")
+        if widget_id == "btn_host_tests":
+            return _("Run Host Tests")
+        if widget_id == "btn_lang":
+            return _("Language:") + f" {get_current_lang_name()}"
+        if widget_id == "btn_exit":
+            return _("Exit")
+        return widget_id
+
+    async def refresh_main_menu(self, *, save: bool = False) -> ServerState:
+        """Re-run discovery and rebuild the root menu without duplicate widget IDs."""
+        state = discover(instance=self.instance, save=save)
+        if self._main_menu is None:
+            return state
+
+        async with self._main_menu.batch():
+            await self._main_menu.remove_children()
+            await self._main_menu.mount_all(self._main_menu_widgets(state))
+        return state
+
+    def request_main_menu_refresh(self, *, save: bool = False) -> None:
+        """Schedule a root menu refresh from sync or worker callbacks."""
+        self.run_worker(
+            self.refresh_main_menu(save=save),
+            name="refresh-main-menu",
+            group="main-menu",
+            exclusive=True,
+            exit_on_error=False,
+        )
+
+    def compose(self) -> ComposeResult:
+        """Create child widgets for the app."""
+        yield Header(show_clock=True)
+        state = discover(instance=self.instance, save=False)
+        with VerticalGroup(id="main-menu") as menu:
+            self._main_menu = menu
+            yield from self._main_menu_widgets(state)
 
         yield Footer()
 
-    def on_button_pressed(self, event: Button.Pressed) -> None:
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
         """Event handler called when a button is pressed."""
         if event.button.id == "btn_exit":
             self.exit(0)
         elif event.button.id == "btn_detect":
-            state = discover(instance=self.instance, save=True)
+            state = await self.refresh_main_menu(save=True)
             if state.server_installed:
                 self.notify(
-                    _("Server files detected! Restart app to see Manage screen."),
+                    _("Server files detected. Main menu updated."),
                     title=_("Success"),
                 )
             elif state.has_install_evidence():

--- a/src/armactl/tui/screens.py
+++ b/src/armactl/tui/screens.py
@@ -107,6 +107,7 @@ class LogWorkerScreen(Screen):
         ("b", "go_back", _("Back to Menu")),
         ("c", "copy_output", _("Copy Output")),
     ]
+    refresh_main_menu_on_return = False
 
     def __init__(self, instance: str, title: str, **kwargs):
         super().__init__(**kwargs)
@@ -133,13 +134,25 @@ class LogWorkerScreen(Screen):
         if event.button.id == "btn_copy_output":
             self.action_copy_output()
         elif event.button.id == "btn_close":
-            self.app.pop_screen()
+            self.run_worker(self._return_to_menu(), group="navigation", exclusive=True)
 
     def action_go_back(self) -> None:
         # Prevent going back if task is not finished
         btn = self.query_one("#btn_close", Button)
         if not btn.disabled:
-            self.app.pop_screen()
+            self.run_worker(self._return_to_menu(), group="navigation", exclusive=True)
+
+    async def _return_to_menu(self) -> None:
+        if self.refresh_main_menu_on_return:
+            refresh = getattr(self.app, "refresh_main_menu", None)
+            if refresh is not None:
+                await refresh()
+        self.app.pop_screen()
+
+    def request_main_menu_refresh(self) -> None:
+        refresh = getattr(self.app, "request_main_menu_refresh", None)
+        if refresh is not None:
+            refresh()
 
     def action_copy_output(self) -> None:
         text = "\n".join(line for line in self._output_lines if line)
@@ -182,11 +195,14 @@ class LogWorkerScreen(Screen):
 class InstallScreen(LogWorkerScreen):
     """Screen for running the server installation."""
 
+    refresh_main_menu_on_return = True
+
     def on_mount(self) -> None:
         self.run_installation_task()
 
     @work(exclusive=True, thread=True)
     def run_installation_task(self) -> None:
+        install_completed = False
         try:
             for message in run_install(self.instance):
                 self.app.call_from_thread(self.append_output, message)
@@ -195,6 +211,7 @@ class InstallScreen(LogWorkerScreen):
                 _("[green]Installation completely finished![/green]"),
                 _("Installation completely finished!"),
             )
+            install_completed = True
         except Exception as e:
             self.app.call_from_thread(
                 self.append_output,
@@ -202,11 +219,15 @@ class InstallScreen(LogWorkerScreen):
                 tr("Installation failed: {error}", error=redact_sensitive_text(e)),
             )
 
+        if install_completed:
+            self.app.call_from_thread(self.request_main_menu_refresh)
         self.app.call_from_thread(self.complete_task)
 
 
 class RepairScreen(LogWorkerScreen):
     """Screen for running the server repair task."""
+
+    refresh_main_menu_on_return = True
 
     def on_mount(self) -> None:
         self.run_repair_task()
@@ -214,6 +235,7 @@ class RepairScreen(LogWorkerScreen):
     @work(exclusive=True, thread=True)
     def run_repair_task(self) -> None:
         state = discover(self.instance, save=False)
+        repair_completed = False
         try:
             # We call run_repair from backend
             for message in run_repair(self.instance, state.install_dir, state.config_path):
@@ -223,6 +245,7 @@ class RepairScreen(LogWorkerScreen):
                 _("[green]Repair completed successfully![/green]"),
                 _("Repair completed successfully!"),
             )
+            repair_completed = True
         except Exception as e:
             self.app.call_from_thread(
                 self.append_output,
@@ -230,6 +253,8 @@ class RepairScreen(LogWorkerScreen):
                 tr("Repair failed: {error}", error=redact_sensitive_text(e)),
             )
 
+        if repair_completed:
+            self.app.call_from_thread(self.request_main_menu_refresh)
         self.app.call_from_thread(self.complete_task)
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1,0 +1,37 @@
+"""Tests for the root TUI app menu helpers."""
+
+from armactl.state import ServerState
+from armactl.tui.app import build_main_menu_entries
+
+
+def _entry_ids(state: ServerState) -> list[str]:
+    return [entry.widget_id for entry in build_main_menu_entries(state)]
+
+
+def test_main_menu_entries_show_manage_for_installed_server() -> None:
+    ids = _entry_ids(ServerState(server_installed=True))
+
+    assert "btn_manage" in ids
+    assert "btn_install" not in ids
+    assert "install-warning" not in ids
+
+
+def test_main_menu_entries_show_install_for_missing_server() -> None:
+    ids = _entry_ids(ServerState(server_installed=False))
+
+    assert "btn_install" in ids
+    assert "btn_manage" not in ids
+    assert "install-warning" not in ids
+
+
+def test_main_menu_entries_warn_before_install_for_partial_server() -> None:
+    ids = _entry_ids(ServerState(server_installed=False, binary_exists=True))
+
+    assert ids.index("install-warning") < ids.index("btn_install")
+    assert "btn_manage" not in ids
+
+
+def test_main_menu_entries_keep_unique_widget_ids() -> None:
+    ids = _entry_ids(ServerState(server_installed=False, binary_exists=True))
+
+    assert len(ids) == len(set(ids))


### PR DESCRIPTION
## Summary

- Made the root TUI main menu refreshable after install, repair, and detect flows.
- Replaced the stale “restart app to see Manage screen” behavior with live menu updates.
- Added serialized main-menu rebuilds to avoid concurrent Textual DOM updates.
- Added tests for state-dependent main menu entries.

## Validation

- [ ] `./scripts/run-host-tests`
- [x] `python3 -m ruff check src tests`
- [x] Focused TUI/locale tests
- [x] Relevant manual flow tested
- [x] TUI flow tested, if this PR changes Textual screens or user interaction
- [x] The changed files are relevant to the linked issue
- [x] This PR does not introduce unrelated changes

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [ ] systemd / timer
- [ ] config.json handling
- [ ] Mods / addon cleanup
- [x] TUI / UX / Textual screens
- [ ] Telegram bot
- [ ] Release / versioning
- [ ] docs only

## Notes

- No migration or rollback required.
- Operator-facing impact: after installation or repair, the main menu updates immediately and shows `Manage Existing Server >>` without restarting `armactl`.