### PR TITLE
chore: prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Semantic Versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-15
+
+### Added
+- Added a unified full-width Textual TUI shell for the main menu and server management views.
+- Added dashboard-style server management with horizontal navigation tabs.
+- Added inline dashboard panels for overview, configuration summary, mods summary, schedule, Telegram bot, cleanup, logs, status, and ports.
+- Added lightweight dashboard formatting helpers and focused TUI layout tests.
+
+### Changed
+- Replaced the old centered button-only main menu with a consistent shell layout.
+- Replaced the left-sidebar dashboard prototype with top navigation that uses terminal width more effectively.
+- Improved TUI action/navigation button sizing so English and Ukrainian labels remain visible.
+- Kept deeper tools such as raw config editing, mods manager, cleanup actions, schedule editor, bot config, and live logs as dedicated screens where appropriate.
+
+### Fixed
+- Fixed stale main menu state after install, repair, or detect flows; the menu now updates without restarting `armactl`.
+- Serialized main menu refreshes to avoid concurrent Textual DOM rebuilds.
+- Fixed top navigation/action labels being truncated after dynamic context changes.
+
 ## [0.3.1] - 2026-05-13
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "armactl"
-version = "0.3.1"
+version = "0.4.0"
 description = "Installer, manager and TUI for Arma Reforger Dedicated Server on Linux"
 readme = "README.md"
 license = "MIT"

--- a/src/armactl/__init__.py
+++ b/src/armactl/__init__.py
@@ -1,3 +1,3 @@
 """armactl - installer, manager and TUI for Arma Reforger Dedicated Server."""
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"


### PR DESCRIPTION
## Summary

- Bumped package version from `0.3.1` to `0.4.0`.
- Updated `CHANGELOG.md` for the unified TUI dashboard release.

## Validation

- [x] `git diff --check`
- [x] `ruff check src tests`
- [x] Focused TUI/i18n tests
- [x] Relevant manual flow tested
- [x] TUI flow tested
- [x] The changed files are relevant to the release
- [x] This PR does not introduce unrelated changes

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [ ] systemd / timer
- [ ] config.json handling
- [ ] Mods / addon cleanup
- [x] TUI / UX / Textual screens
- [ ] Telegram bot
- [x] Release / versioning
- [ ] docs only

## Notes

- No migration required.
- Operator-facing impact: armactl now uses a unified dashboard-style TUI shell with horizontal navigation and improved menu refresh behavior.