### PR TITLE
fix(tui): avoid duplicate refresh action buttons

### DIFF
--- a/src/armactl/tui/screens.py
+++ b/src/armactl/tui/screens.py
@@ -1225,31 +1225,24 @@ class ManageScreen(Screen):
             ],
             "mods": [
                 ("open_mods", _("Mods Manager"), "primary"),
-                ("refresh", _("Refresh Status"), "default"),
             ],
             "schedule": [
                 ("open_schedule", _("Restart Schedule"), "primary"),
-                ("refresh", _("Refresh Status"), "default"),
             ],
             "bot": [
                 ("open_bot", _("Telegram Bot"), "primary"),
-                ("refresh", _("Refresh Status"), "default"),
             ],
             "cleanup": [
                 ("open_cleanup", _("Maintenance / Cleanup"), "warning"),
-                ("refresh", _("Refresh Status"), "default"),
             ],
             "logs": [
                 ("open_live_logs", _("Live Logs"), "primary"),
-                ("refresh", _("Refresh Status"), "default"),
             ],
             "status": [
-                ("refresh", _("Refresh Status"), "primary"),
-                ("open_schedule", _("Restart Schedule"), "default"),
+                ("open_schedule", _("Restart Schedule"), "primary"),
             ],
             "ports": [
-                ("refresh", _("Refresh Status"), "primary"),
-                ("open_config", _("Config"), "default"),
+                ("open_config", _("Config"), "primary"),
             ],
         }
         return actions.get(self._active_panel, actions["overview"])
@@ -1280,9 +1273,7 @@ class ManageScreen(Screen):
         self.action_refresh_state()
 
     def _handle_context_action(self, action_key: str) -> None:
-        if action_key == "refresh":
-            self.action_refresh_state()
-        elif action_key == "open_config":
+        if action_key == "open_config":
             self.app.push_screen(ConfigEditorScreen(self.instance))
         elif action_key == "open_raw_config":
             self.app.push_screen(RawConfigScreen(self.instance))

--- a/tests/test_tui_dashboard.py
+++ b/tests/test_tui_dashboard.py
@@ -7,7 +7,7 @@ from rich.cells import cell_len
 from textual.app import App, ComposeResult
 from textual.widgets import Button
 
-from armactl.i18n import using_lang
+from armactl.i18n import _, using_lang
 from armactl.tui.app import ArmaCtlApp
 from armactl.tui.dashboard import format_player_count, format_usage_bar
 from armactl.tui.screens import ManageScreen
@@ -85,6 +85,14 @@ def test_manage_context_actions_keep_deep_screens_out_of_primary_tabs() -> None:
     ]
 
 
+def test_manage_context_actions_do_not_duplicate_global_refresh() -> None:
+    screen = ManageScreen("default")
+
+    for panel, _button_id, _label in screen._nav_items():
+        screen._active_panel = panel
+        assert "refresh" not in [action[0] for action in screen._context_actions()]
+
+
 def test_manage_top_bars_fit_english_and_ukrainian_labels() -> None:
     async def run_case(lang: str) -> None:
         with (
@@ -109,6 +117,38 @@ def test_manage_top_bars_fit_english_and_ukrainian_labels() -> None:
                     await pilot.pause()
                     for button in screen.query("#manage-action-row Button").results(Button):
                         _assert_button_label_fits(button)
+
+    for lang in ("en", "uk"):
+        asyncio.run(run_case(lang))
+
+
+def test_manage_action_row_keeps_one_global_refresh_button() -> None:
+    async def run_case(lang: str) -> None:
+        with (
+            using_lang(lang),
+            patch.object(ManageScreen, "action_refresh_state", lambda self: None),
+        ):
+            async with ManageSmokeApp().run_test(size=(70, 24)) as pilot:
+                await pilot.pause()
+                screen = pilot.app.screen
+
+                for panel, _button_id, _label in screen._nav_items():
+                    screen._active_panel = panel
+                    screen._update_context_actions()
+                    await pilot.pause()
+
+                    buttons = list(screen.query("#manage-action-row Button").results(Button))
+                    labels = [_button_label(button) for button in buttons]
+                    assert labels.count(_("Refresh Status")) == 1
+
+                    refresh_button = screen.query_one("#btn_refresh_manage", Button)
+                    assert _button_label(refresh_button) == _("Refresh Status")
+                    assert not refresh_button.disabled
+
+                    secondary = screen.query_one("#btn_context_secondary", Button)
+                    if len(screen._context_actions()) == 1:
+                        assert secondary.disabled
+                        assert _button_label(secondary) == ""
 
     for lang in ("en", "uk"):
         asyncio.run(run_case(lang))


### PR DESCRIPTION
## Summary

- Removed duplicate panel-specific `Refresh Status` context actions from the unified TUI dashboard.
- Kept the global `Refresh Status` button as the single refresh action in the manage action bar.
- Updated single-action dashboard tabs so unused secondary context buttons are disabled and empty.
- Added focused tests for duplicate refresh prevention and context-button state.

## Related issue

Closes #

## Validation

- [x] `git diff --check`
- [x] `ruff check src tests`
- [x] `pytest tests/test_tui_app.py tests/test_tui_dashboard.py tests/test_i18n.py`
- [x] Relevant manual flow tested
- [x] TUI flow tested, if this PR changes Textual screens or user interaction
- [x] The changed files are relevant to the linked issue
- [x] This PR does not introduce unrelated changes

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [ ] systemd / timer
- [ ] config.json handling
- [ ] Mods / addon cleanup
- [x] TUI / UX / Textual screens
- [ ] Telegram bot
- [ ] Release / versioning
- [ ] docs only

## Automated contribution disclosure

- [x] This PR was written or substantially reviewed by a human maintainer/contributor
- [x] This is not a low-effort automated bounty submission
- [x] If AI or automation was used, the generated changes were manually reviewed

## Notes

- No migration or rollback required.
- Operator-facing impact: dashboard tabs no longer show duplicate `Refresh Status` buttons.
- This is intentionally not a release bump; the fix can ship on `main` first and be included in a later patch release if needed.