### PR TITLE
Prepare v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ Semantic Versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-15
+
+### Added
+- Added real Arma Reforger Dedicated Server FPS/frame-time telemetry from the server engine's `-logStats 10000` output.
+- Added `Server FPS`, average frame time, maximum frame time, and telemetry age to `armactl status`.
+- Added Server FPS/frame-time display to the TUI overview/status views.
+- Added Server FPS/frame-time display to Telegram bot metrics.
+- Added stale, missing, malformed, and unavailable telemetry handling for server FPS metrics.
+- Added focused parser, CLI, TUI, Telegram, and generated start-script tests for FPS telemetry.
+
+### Changed
+- Generated `start-armareforger.sh` now starts `ArmaReforgerServer` with `-logStats 10000` before `-maxFPS`.
+- Metrics now distinguish real server engine FPS from generic host CPU/RAM metrics.
+
+### Notes
+- Server FPS is parsed from the Arma Reforger engine log output and is not estimated from CPU usage.
+- Existing installations should regenerate the start script and restart `armareforger.service` to enable FPS telemetry.
+
 ## [0.4.0] - 2026-05-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# armactl
+# armactl
 
 [![CI](https://github.com/dturovskiy/armactl/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/dturovskiy/armactl/actions/workflows/ci.yml)
 [![Latest Release](https://img.shields.io/github/v/release/dturovskiy/armactl)](https://github.com/dturovskiy/armactl/releases)
@@ -78,6 +78,7 @@ refreshes `state.json`.
 - manage mods: add, remove, dedupe, import, export
 - manage scheduled restarts through `systemd`
 - expose optional Telegram bot controls
+- show real Arma Reforger server FPS/frame-time telemetry when `-logStats` data is available
 - keep runtime data separated from repo code
 
 ## Scheduled restarts
@@ -92,6 +93,38 @@ In TUI, `Restart Schedule` accepts exact times instead of raw `systemd` syntax:
 
 `armactl` converts those values into the correct `OnCalendar=` entries in the
 timer unit automatically.
+
+## Server FPS telemetry
+
+`armactl` can show real Arma Reforger Dedicated Server FPS and frame-time
+telemetry.
+
+For generated services, `start-armareforger.sh` starts the server with:
+
+```text
+-logStats 10000
+```
+
+The server writes periodic engine telemetry into the runtime console log, and
+`armactl` reads the latest valid `FPS:` line from:
+
+```text
+~/armactl-data/<instance>/config/logs/*/console.log
+```
+
+Example:
+
+```text
+Server FPS:  60.0
+Frame time:  16.7 ms avg / 18.5 ms max
+Telemetry:   4s old
+```
+
+This value is the server engine's own FPS telemetry. It is not estimated from
+CPU usage.
+
+For existing installations, regenerate the service/start script and restart the
+server after updating `armactl` so the process starts with `-logStats 10000`.
 
 ## Runtime layout
 
@@ -139,6 +172,7 @@ Current bot capabilities include:
 - start / stop / restart
 - scheduled restart management
 - player visibility through A2S and local RCON
+- real Server FPS/frame-time metrics when server telemetry is available
 
 See [docs/telegram-bot.md](docs/telegram-bot.md) for the full flow.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,6 +97,7 @@ armactl/
 | `cleaner.py` | Аналіз і прибирання старих логів, dump-файлів і backup-ів |
 | `i18n.py` | Локалізація UI та backend-повідомлень |
 | `logs.py` | Читання journalctl логів |
+| `metrics.py` | Runtime метрики сервера: CPU/RAM, PID-level state, Server FPS/frame-time telemetry |
 | `ports.py` | Перевірка listening портів (ss) |
 
 ---
@@ -206,6 +207,20 @@ ExecStart=/home/<user>/armactl-data/default/start-armareforger.sh
 ---
 
 ## 5. Потоки даних
+
+### Server FPS telemetry flow
+
+```text
+generated start-armareforger.sh
+  → ArmaReforgerServer -logStats 10000
+  → config/logs/*/console.log
+  → metrics.query_server_fps_metrics()
+  → CLI status / TUI status / Telegram metrics
+```
+
+`armactl` treats FPS as engine telemetry, not as a derived host metric. If the
+latest log line is missing, stale, or malformed, the UI reports the telemetry as
+unavailable/stale instead of inventing a value.
 
 ### Install flow
 

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -203,6 +203,8 @@
 - [x] Додати success notifications
 - [x] Додати masking для паролів
 - [x] Перевірити, що секрети не течуть у логах
+- [x] Додати показ реального Server FPS/frame-time через `-logStats`
+- [x] Додати stale/unavailable handling для FPS telemetry
 
 ## Phase 14 — Тести
 
@@ -222,6 +224,9 @@
 - [x] Описати режим existing server
 - [x] Описати repair mode
 - [x] Додати changelog
+- [x] Перевірити Server FPS telemetry на live сервері
+- [x] Перевірити `./armactl status` після merge в `main`
+- [ ] Підготувати GitHub release `v0.5.0`
 - [ ] Підготувати перший GitHub release
 - [ ] Перевірити встановлення з релізного архіву
 - [ ] Перевірити запуск на іншій машині

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,6 +19,28 @@ model as the main product.
 .venv/bin/ruff check src tests
 ```
 
+## Server FPS telemetry development notes
+
+Server FPS metrics are parsed from Arma Reforger's `-logStats` console output.
+
+When changing this area, cover at least:
+
+- latest log directory selection
+- valid `FPS:` line parsing
+- malformed telemetry lines
+- missing logs
+- stale telemetry
+- CLI/TUI/Telegram rendering
+- generated `start-armareforger.sh` arguments
+
+Manual smoke check on a live server:
+
+```bash
+pgrep -af ArmaReforgerServer
+grep -RiaE 'FPS:|frame time' ~/armactl-data/default/config/logs | tail -20
+./armactl status
+```
+
 ## Project structure
 
 - `src/armactl/` — backend modules, CLI, TUI, Telegram bot

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -19,6 +19,11 @@ Ship a GitHub Release that matches the repo-local operational model of
   - fresh install
   - existing server
   - reboot flow
+- Confirm Server FPS telemetry on a live server:
+  - generated process args include `-logStats 10000`
+  - runtime `console.log` contains `FPS:` / `frame time`
+  - `./armactl status` shows `Server FPS`, `Frame time`, and telemetry age
+  - TUI and Telegram metrics do not crash when telemetry is missing or stale
 
 ## Tagging
 
@@ -42,3 +47,5 @@ The GitHub release workflow should:
 - Verify installation from the release archive
 - Verify `./armactl` on another machine
 - Check release notes and attached artifacts
+- Verify an existing installation can regenerate the start script and show
+  Server FPS after restarting `armareforger.service`

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -13,9 +13,9 @@ Current status:
 - `armactl-bot.service` can now be installed and managed from the TUI
 - bot actions use a narrow root-owned helper plus a sudoers drop-in instead of
   storing a password or attempting interactive sudo from the bot process
-- `/status` now includes server CPU/RAM, best-effort player counts via the
-  configured local A2S query port, and player roster details via local RCON
-  when RCON is configured
+- `/status` now includes server CPU/RAM, real Server FPS/frame-time telemetry
+  when available, best-effort player counts via the configured local A2S query
+  port, and player roster details via local RCON when RCON is configured
 
 ## Goals
 
@@ -82,6 +82,7 @@ of the same `.env` file must produce the same final state that the TUI sees.
 - `/stop` stops the server
 - `/restart` restarts the server
 - `/schedule 05:00, 20:00` updates scheduled restart times
+- metrics view shows Server FPS/frame-time when `-logStats` telemetry is available
 - access is restricted by `ARMACTL_BOT_ADMIN_CHAT_IDS`
 
 ## Library choice

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -102,6 +102,50 @@ Check:
 systemctl show armareforger.service --property=MainPID,MemoryCurrent,CPUUsageNSec
 ```
 
+## Server FPS telemetry is unavailable or stale
+
+Symptoms:
+
+- `armactl status` shows Server FPS as unavailable
+- TUI or Telegram metrics do not show FPS/frame-time
+- telemetry age is stale
+
+Check that the running server process includes `-logStats 10000`:
+
+```bash
+pgrep -af ArmaReforgerServer
+```
+
+Expected fragment:
+
+```text
+-logStats 10000 -maxFPS
+```
+
+Check that the server is writing FPS telemetry:
+
+```bash
+grep -RiaE 'FPS:|frame time' ~/armactl-data/default/config/logs | tail -20
+```
+
+Check service logs:
+
+```bash
+sudo journalctl -u armareforger.service -n 200 --no-pager
+```
+
+If `-logStats 10000` is missing, regenerate the service/start script through
+repair or service generation, then restart the server:
+
+```bash
+./armactl repair
+sudo systemctl restart armareforger.service
+./armactl status
+```
+
+If `-logStats 10000` is present but no `FPS:` lines appear, wait for the next
+telemetry interval and re-check the runtime logs.
+
 ## Existing service is found but config or binary is wrong
 
 Use:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "armactl"
-version = "0.4.0"
+version = "0.5.0"
 description = "Installer, manager and TUI for Arma Reforger Dedicated Server on Linux"
 readme = "README.md"
 license = "MIT"

--- a/src/armactl/__init__.py
+++ b/src/armactl/__init__.py
@@ -1,3 +1,3 @@
 """armactl - installer, manager and TUI for Arma Reforger Dedicated Server."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"


### PR DESCRIPTION
## Summary

Prepares the `v0.5.0` release after merging Server FPS telemetry support.

## Changes

- Bumps package version from `0.4.0` to `0.5.0`.
- Updates `CHANGELOG.md` with the Server FPS telemetry release notes.
- Documents real Server FPS/frame-time telemetry in README and project docs.
- Adds troubleshooting guidance for missing or stale FPS telemetry.
- Updates release checklist/process docs with live telemetry smoke checks.

## Validation

- `git diff --check`
- `ruff check src tests`
- `pytest -q`

## Live smoke already confirmed

- `ArmaReforgerServer` runs with `-logStats 10000`.
- Runtime `console.log` contains FPS/frame-time telemetry.
- `./armactl status` shows real `Server FPS`, `Frame time`, and telemetry age.