### PR TITLE
title: Harden Telegram bot callbacks and add diagnostics report

### DIFF
--- a/src/armactl/cli.py
+++ b/src/armactl/cli.py
@@ -284,6 +284,22 @@ def logs(ctx: click.Context, lines: int, follow: bool) -> None:
     sys.exit(exit_code)
 
 
+@main.command()
+@click.option("-n", "--lines", default=120, help="Journal lines to include per unit.")
+@click.option("--no-journal", is_flag=True, default=False, help="Skip journalctl sections.")
+@click.pass_context
+def report(ctx: click.Context, lines: int, no_journal: bool) -> None:
+    """Print a redacted support/debug diagnostic report."""
+    from armactl.report import build_report
+
+    instance = ctx.obj["instance"]
+    text = build_report(instance=instance, lines=lines, include_journal=not no_journal)
+    if ctx.obj["json"]:
+        click.echo(json.dumps({"instance": instance, "report": text}))
+        return
+    click.echo(text, nl=False)
+
+
 @main.group(invoke_without_command=True)
 @click.pass_context
 def ports(ctx: click.Context) -> None:

--- a/src/armactl/report.py
+++ b/src/armactl/report.py
@@ -6,9 +6,9 @@ import json
 import os
 import platform
 import subprocess
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable
 
 from armactl import __version__, paths
 from armactl.discovery import discover
@@ -174,7 +174,10 @@ def build_report(
             "\n".join(
                 [
                     command_runner(["git", "-C", str(project_root), "branch", "--show-current"], 5),
-                    command_runner(["git", "-C", str(project_root), "rev-parse", "--short", "HEAD"], 5),
+                    command_runner(
+                        ["git", "-C", str(project_root), "rev-parse", "--short", "HEAD"],
+                        5,
+                    ),
                     command_runner(["git", "-C", str(project_root), "status", "--short"], 5),
                 ]
             ),

--- a/src/armactl/report.py
+++ b/src/armactl/report.py
@@ -1,0 +1,278 @@
+"""Diagnostic report collection for support/debugging output."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+from armactl import __version__, paths
+from armactl.discovery import discover
+from armactl.redaction import redact_sensitive_text
+from armactl.service_manager import (
+    get_service_status,
+    get_timer_status,
+    service_unit_name,
+    timer_unit_name,
+)
+
+CommandRunner = Callable[[list[str], int], str]
+
+
+SENSITIVE_FILE_NAMES = {".env", "config.json"}
+FPS_LINE_MARKERS = ("FPS:", "frame time")
+
+
+def _section(title: str, body: str) -> str:
+    """Render a report section with a stable plain-text header."""
+    clean_body = redact_sensitive_text(body).rstrip()
+    if not clean_body:
+        clean_body = "(no output)"
+    return f"== {title} ==\n{clean_body}\n"
+
+
+def _run_command(cmd: list[str], timeout: int = 10) -> str:
+    """Run a read-only diagnostic command and return redacted output."""
+    try:
+        result = subprocess.run(  # noqa: S603 - diagnostic command argv is fixed by caller
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError:
+        return f"$ {' '.join(cmd)}\ncommand not found"
+    except subprocess.TimeoutExpired:
+        return f"$ {' '.join(cmd)}\ntimed out after {timeout}s"
+    except OSError as error:
+        return f"$ {' '.join(cmd)}\nfailed: {error}"
+
+    output_parts = [f"$ {' '.join(cmd)}"]
+    if result.stdout.strip():
+        output_parts.append(result.stdout.rstrip())
+    if result.stderr.strip():
+        output_parts.append("stderr:")
+        output_parts.append(result.stderr.rstrip())
+    if result.returncode != 0:
+        output_parts.append(f"exit_code: {result.returncode}")
+    return redact_sensitive_text("\n".join(output_parts))
+
+
+def _read_text_file(path: Path, *, max_bytes: int = 64_000) -> str:
+    """Read a small diagnostic text file safely."""
+    if not path.exists():
+        return f"{path}: missing"
+    if not path.is_file():
+        return f"{path}: not a file"
+    try:
+        data = path.read_bytes()
+    except OSError as error:
+        return f"{path}: failed to read: {error}"
+
+    truncated = len(data) > max_bytes
+    if truncated:
+        data = data[-max_bytes:]
+    text = data.decode("utf-8", errors="replace")
+    if truncated:
+        text = f"... truncated to last {max_bytes} bytes ...\n{text}"
+    return redact_sensitive_text(text)
+
+
+def _file_exists_line(label: str, path: Path) -> str:
+    """Return a compact file presence line."""
+    try:
+        exists = path.exists()
+        is_file = path.is_file()
+    except OSError as error:
+        return f"{label}: {path} (error: {error})"
+    status = "file" if is_file else "exists" if exists else "missing"
+    return f"{label}: {path} ({status})"
+
+
+def _latest_console_log(config_dir: Path) -> Path | None:
+    """Return the newest runtime console.log under the profile logs directory."""
+    logs_dir = config_dir / "logs"
+    try:
+        candidates = list(logs_dir.glob("*/console.log"))
+    except OSError:
+        return None
+    if not candidates:
+        return None
+    return max(candidates, key=lambda path: path.stat().st_mtime)
+
+
+def _tail_matching_lines(path: Path, markers: tuple[str, ...], limit: int = 10) -> str:
+    """Return the last lines containing any marker from a text file."""
+    if not path.exists():
+        return f"{path}: missing"
+    matches: list[str] = []
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                if any(marker in line for marker in markers):
+                    matches.append(line.rstrip())
+    except OSError as error:
+        return f"{path}: failed to read: {error}"
+    if not matches:
+        return f"{path}: no matching lines"
+    return "\n".join(matches[-limit:])
+
+
+def _json_block(value: object) -> str:
+    """Render a JSON block with secret redaction."""
+    return redact_sensitive_text(json.dumps(value, indent=2, ensure_ascii=False, default=str))
+
+
+def build_report(
+    instance: str = paths.DEFAULT_INSTANCE_NAME,
+    *,
+    lines: int = 120,
+    include_journal: bool = True,
+    command_runner: CommandRunner = _run_command,
+) -> str:
+    """Build a copy-paste friendly diagnostic report for an armactl instance."""
+    lines = max(int(lines), 1)
+    sections: list[str] = []
+    project_root = paths.project_root()
+    instance_root = paths.instance_root(instance)
+    config_dir = paths.config_dir(instance)
+    config_file = paths.config_file(instance)
+    start_script = paths.start_script(instance)
+    server_binary = paths.server_binary(instance)
+    bot_env_file = paths.bot_env_file(instance)
+    state_file = paths.state_file(instance)
+    service_name = service_unit_name(instance)
+    timer_name = timer_unit_name(instance)
+    bot_service_name = paths.BOT_SERVICE_NAME
+
+    sections.append(
+        _section(
+            "armactl report",
+            "\n".join(
+                [
+                    f"timestamp_utc: {datetime.now(timezone.utc).isoformat()}",
+                    f"armactl_version: {__version__}",
+                    f"instance: {instance}",
+                    f"python: {platform.python_version()}",
+                    f"platform: {platform.platform()}",
+                    f"cwd: {Path.cwd()}",
+                    f"project_root: {project_root}",
+                    f"user: {os.environ.get('USER', 'unknown')}",
+                ]
+            ),
+        )
+    )
+
+    sections.append(
+        _section(
+            "git",
+            "\n".join(
+                [
+                    command_runner(["git", "-C", str(project_root), "branch", "--show-current"], 5),
+                    command_runner(["git", "-C", str(project_root), "rev-parse", "--short", "HEAD"], 5),
+                    command_runner(["git", "-C", str(project_root), "status", "--short"], 5),
+                ]
+            ),
+        )
+    )
+
+    try:
+        state = discover(instance=instance, save=False)
+        sections.append(_section("discovery", _json_block(state.to_dict())))
+    except Exception as error:  # noqa: BLE001 - reports should not fail on diagnostics
+        state = None
+        sections.append(_section("discovery", f"failed: {error}"))
+
+    try:
+        service_status = get_service_status(service_name)
+    except Exception as error:  # noqa: BLE001
+        service_status = {"error": str(error)}
+    try:
+        timer_status = get_timer_status(timer_name)
+    except Exception as error:  # noqa: BLE001
+        timer_status = {"error": str(error)}
+
+    sections.append(
+        _section(
+            "runtime paths",
+            "\n".join(
+                [
+                    f"instance_root: {instance_root}",
+                    _file_exists_line("server_binary", server_binary),
+                    _file_exists_line("config_file", config_file),
+                    _file_exists_line("state_file", state_file),
+                    _file_exists_line("start_script", start_script),
+                    _file_exists_line("bot_env", bot_env_file),
+                ]
+            ),
+        )
+    )
+
+    sections.append(_section("service status dict", _json_block(service_status)))
+    sections.append(_section("timer status dict", _json_block(timer_status)))
+    sections.append(_section("process", command_runner(["pgrep", "-af", "ArmaReforgerServer"], 5)))
+    sections.append(_section("start script", _read_text_file(start_script)))
+
+    latest_log = _latest_console_log(config_dir)
+    fps_body = [f"latest_console_log: {latest_log or '(none)'}"]
+    if latest_log is not None:
+        fps_body.append(_tail_matching_lines(latest_log, FPS_LINE_MARKERS, limit=10))
+    sections.append(_section("server FPS telemetry", "\n".join(fps_body)))
+
+    service_names = [service_name, timer_name, bot_service_name]
+    sections.append(
+        _section(
+            "systemctl status",
+            "\n\n".join(
+                command_runner(["systemctl", "status", name, "--no-pager"], 10)
+                for name in service_names
+            ),
+        )
+    )
+
+    if include_journal:
+        sections.append(
+            _section(
+                "journalctl server",
+                command_runner(
+                    ["journalctl", "-u", service_name, "-n", str(lines), "--no-pager"],
+                    15,
+                ),
+            )
+        )
+        sections.append(
+            _section(
+                "journalctl bot",
+                command_runner(
+                    ["journalctl", "-u", bot_service_name, "-n", str(lines), "--no-pager"],
+                    15,
+                ),
+            )
+        )
+
+    port_patterns: list[str] = []
+    if state is not None:
+        for port in (state.ports.game, state.ports.a2s, state.ports.rcon):
+            if port:
+                port_patterns.append(f":{port}")
+    if port_patterns:
+        sections.append(
+            _section(
+                "listening UDP ports",
+                "\n".join(
+                    [
+                        command_runner(["ss", "-lunp"], 10),
+                        f"expected_port_markers: {', '.join(port_patterns)}",
+                    ]
+                ),
+            )
+        )
+    else:
+        sections.append(_section("listening UDP ports", command_runner(["ss", "-lunp"], 10)))
+
+    return "\n".join(sections).rstrip() + "\n"

--- a/src/armactl/telegram_bot.py
+++ b/src/armactl/telegram_bot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import logging
 import re
 import sys
@@ -76,6 +77,24 @@ def _icon_line(icon: str, text: str) -> str:
 def _bullet_line(text: str) -> str:
     """Render a simple bullet line for Telegram text blocks."""
     return f"{BULLET} {text}"
+
+
+def _telegram_error_name(error: BaseException) -> str:
+    """Return the short class name for a Telegram/PTB exception."""
+    return error.__class__.__name__
+
+
+def _is_telegram_network_error(error: BaseException) -> bool:
+    """Return whether an exception looks like a transient Telegram API failure."""
+    return _telegram_error_name(error) in {"NetworkError", "TimedOut"}
+
+
+def _is_message_not_modified_error(error: BaseException) -> bool:
+    """Return whether Telegram rejected a no-op message edit."""
+    return (
+        _telegram_error_name(error) == "BadRequest"
+        and "Message is not modified" in str(error)
+    )
 
 
 @dataclass
@@ -903,12 +922,13 @@ class ArmaCtlTelegramBot:
         )
 
         if getattr(update, "callback_query", None) is not None:
-            await update.callback_query.answer(
+            await self._safe_answer_callback(
+                update.callback_query,
                 self.t("Access denied."),
                 show_alert=True,
             )
         elif getattr(update, "effective_message", None) is not None:
-            await update.effective_message.reply_text(message)
+            await self._safe_reply_text(update.effective_message, message)
 
     async def _ensure_allowed(self, update) -> bool:
         chat = getattr(update, "effective_chat", None)
@@ -917,12 +937,65 @@ class ArmaCtlTelegramBot:
             return False
         return True
 
+    async def _safe_answer_callback(
+        self,
+        query,
+        text: str | None = None,
+        *,
+        show_alert: bool = False,
+    ) -> None:
+        """Acknowledge a callback without aborting the handler on network blips."""
+        try:
+            await query.answer(text=text, show_alert=show_alert)
+        except Exception as error:
+            if _is_telegram_network_error(error):
+                LOGGER.warning(
+                    "Telegram callback answer failed: %s",
+                    redact_sensitive_text(error),
+                )
+                return
+            raise
+
+    async def _safe_edit_message_text(self, query, text: str, markup) -> None:
+        """Edit a callback message while tolerating no-op edits and network blips."""
+        for attempt in range(2):
+            try:
+                await query.edit_message_text(text=text, reply_markup=markup)
+                return
+            except Exception as error:
+                if _is_message_not_modified_error(error):
+                    LOGGER.debug("Telegram message edit skipped: message is not modified")
+                    return
+                if _is_telegram_network_error(error):
+                    if attempt == 0:
+                        await asyncio.sleep(0.2)
+                        continue
+                    LOGGER.warning(
+                        "Telegram message edit failed: %s",
+                        redact_sensitive_text(error),
+                    )
+                    return
+                raise
+
+    async def _safe_reply_text(self, message, text: str, markup=None) -> None:
+        """Send a text reply while logging transient Telegram network failures."""
+        try:
+            await message.reply_text(text, reply_markup=markup)
+        except Exception as error:
+            if _is_telegram_network_error(error):
+                LOGGER.warning(
+                    "Telegram message reply failed: %s",
+                    redact_sensitive_text(error),
+                )
+                return
+            raise
+
     async def _reply_with_menu(self, update, text: str, markup=None) -> None:
         markup = markup or self._main_keyboard()
         if getattr(update, "callback_query", None) is not None:
-            await update.callback_query.edit_message_text(text=text, reply_markup=markup)
+            await self._safe_edit_message_text(update.callback_query, text, markup)
         else:
-            await update.effective_message.reply_text(text, reply_markup=markup)
+            await self._safe_reply_text(update.effective_message, text, markup)
 
     async def _apply_schedule_input(self, update, raw_value: str) -> None:
         schedule_entries = parse_friendly_schedule_input(raw_value)
@@ -963,7 +1036,7 @@ class ArmaCtlTelegramBot:
 
     async def _edit_message(self, query, text: str, markup) -> None:
         """Edit an existing callback message with an explicit keyboard."""
-        await query.edit_message_text(text=text, reply_markup=markup)
+        await self._safe_edit_message_text(query, text, markup)
 
     def _call_backend(self, fn, *args):
         with using_lang(self.lang):
@@ -1069,7 +1142,7 @@ class ArmaCtlTelegramBot:
             return
 
         query = update.callback_query
-        await query.answer()
+        await self._safe_answer_callback(query)
         data = query.data or ""
         if data != "schedule:edit":
             self._clear_pending_schedule_input(update)
@@ -1205,6 +1278,20 @@ class ArmaCtlTelegramBot:
                 self._schedule_keyboard(),
             )
 
+    async def error_handler(self, update, context) -> None:
+        """Log Telegram handler errors without exposing secrets or noisy no-op edits."""
+        error = getattr(context, "error", None)
+        if error is None:
+            LOGGER.error("Telegram update failed without an attached exception")
+            return
+        if _is_message_not_modified_error(error):
+            LOGGER.debug("Telegram update skipped: message is not modified")
+            return
+        if _is_telegram_network_error(error):
+            LOGGER.warning("Telegram network error: %s", redact_sensitive_text(error))
+            return
+        LOGGER.exception("Telegram update failed: %s", redact_sensitive_text(error))
+
     def build_application(self):
         """Create and configure the PTB Application."""
         try:
@@ -1240,6 +1327,7 @@ class ArmaCtlTelegramBot:
             MessageHandler(filters.TEXT & ~filters.COMMAND, self.text_message_handler)
         )
         application.add_handler(CallbackQueryHandler(self.callback_handler))
+        application.add_error_handler(self.error_handler)
         application.run_polling(allowed_updates=Update.ALL_TYPES)
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -32,7 +32,10 @@ def test_build_report_redacts_secrets_and_keeps_sections(monkeypatch):
     monkeypatch.setattr(report, "get_timer_status", lambda name: {"enabled": True})
 
     def command_runner(cmd: list[str], timeout: int) -> str:
-        return "$ " + " ".join(cmd) + "\npassword=supersecret\nARMACTL_BOT_TOKEN=123456:ABCDEFSECRET"
+        return (
+            "$ " + " ".join(cmd)
+            + "\npassword=supersecret\nARMACTL_BOT_TOKEN=123456:ABCDEFSECRET"
+        )
 
     text = report.build_report(
         "default",
@@ -52,7 +55,9 @@ def test_build_report_redacts_secrets_and_keeps_sections(monkeypatch):
 def test_cli_report_command_prints_report(monkeypatch):
     monkeypatch.setattr(
         "armactl.report.build_report",
-        lambda instance, lines, include_journal: f"report for {instance} {lines} {include_journal}\n",
+        lambda instance, lines, include_journal: (
+            f"report for {instance} {lines} {include_journal}\n"
+        ),
     )
 
     result = CliRunner().invoke(main, ["--instance", "default", "report", "--no-journal"])

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,61 @@
+"""Tests for diagnostic support report generation."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from armactl import report
+from armactl.cli import main
+from armactl.state import PortInfo, ServerState
+
+
+def test_build_report_redacts_secrets_and_keeps_sections(monkeypatch):
+    state = ServerState(
+        server_installed=True,
+        binary_exists=True,
+        config_exists=True,
+        service_exists=True,
+        timer_exists=True,
+        server_running=True,
+        instance_root="/srv/armactl-data/default",
+        install_dir="/srv/armactl-data/default/server",
+        config_path="/srv/armactl-data/default/config/config.json",
+        ports=PortInfo(game=2001, a2s=17777, rcon=19999),
+    )
+
+    monkeypatch.setattr(report, "discover", lambda instance, save=False: state)
+    monkeypatch.setattr(
+        report,
+        "get_service_status",
+        lambda name: {"active": True, "main_pid": 1234, "secret": "token=123456:SECRET"},
+    )
+    monkeypatch.setattr(report, "get_timer_status", lambda name: {"enabled": True})
+
+    def command_runner(cmd: list[str], timeout: int) -> str:
+        return "$ " + " ".join(cmd) + "\npassword=supersecret\nARMACTL_BOT_TOKEN=123456:ABCDEFSECRET"
+
+    text = report.build_report(
+        "default",
+        include_journal=False,
+        command_runner=command_runner,
+    )
+
+    assert "== armactl report ==" in text
+    assert "== process ==" in text
+    assert "== server FPS telemetry ==" in text
+    assert "supersecret" not in text
+    assert "123456:ABCDEFSECRET" not in text
+    assert "password=***" in text
+    assert "ARMACTL_BOT_TOKEN=***" in text
+
+
+def test_cli_report_command_prints_report(monkeypatch):
+    monkeypatch.setattr(
+        "armactl.report.build_report",
+        lambda instance, lines, include_journal: f"report for {instance} {lines} {include_journal}\n",
+    )
+
+    result = CliRunner().invoke(main, ["--instance", "default", "report", "--no-journal"])
+
+    assert result.exit_code == 0
+    assert result.output == "report for default 120 False\n"

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -434,3 +434,92 @@ def test_parse_friendly_schedule_input_accepts_simple_times():
 
 def test_parse_friendly_schedule_input_rejects_non_time_text():
     assert telegram_bot.parse_friendly_schedule_input("tomorrow at six") == []
+
+
+def _test_bot() -> telegram_bot.ArmaCtlTelegramBot:
+    config = types.SimpleNamespace(
+        instance="default",
+        language="en",
+        enabled=True,
+        token="token",
+        admin_chat_ids=["1"],
+    )
+    with mock.patch("armactl.telegram_bot.load_bot_config", return_value=config):
+        return telegram_bot.ArmaCtlTelegramBot("default")
+
+
+class NetworkError(Exception):
+    pass
+
+
+class TimedOut(Exception):
+    pass
+
+
+class BadRequest(Exception):
+    pass
+
+
+def test_safe_answer_callback_ignores_telegram_network_errors():
+    import asyncio
+
+    bot = _test_bot()
+
+    class Query:
+        async def answer(self, **kwargs):
+            raise NetworkError("temporary read error")
+
+    asyncio.run(bot._safe_answer_callback(Query()))
+
+
+def test_safe_edit_message_text_ignores_message_not_modified():
+    import asyncio
+
+    bot = _test_bot()
+
+    class Query:
+        async def edit_message_text(self, **kwargs):
+            raise BadRequest(
+                "Message is not modified: specified new message content and reply "
+                "markup are exactly the same"
+            )
+
+    asyncio.run(bot._safe_edit_message_text(Query(), "same", object()))
+
+
+def test_safe_edit_message_text_retries_transient_network_error():
+    import asyncio
+
+    bot = _test_bot()
+
+    class Query:
+        def __init__(self):
+            self.calls = 0
+
+        async def edit_message_text(self, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                raise TimedOut("telegram timeout")
+
+    query = Query()
+
+    asyncio.run(bot._safe_edit_message_text(query, "new", object()))
+
+    assert query.calls == 2
+
+
+def test_safe_edit_message_text_reraises_unknown_errors():
+    import asyncio
+
+    bot = _test_bot()
+
+    class Query:
+        async def edit_message_text(self, **kwargs):
+            raise RuntimeError("unexpected failure")
+
+    try:
+        asyncio.run(bot._safe_edit_message_text(Query(), "new", object()))
+    except RuntimeError as error:
+        assert "unexpected failure" in str(error)
+    else:  # pragma: no cover - explicit assertion path for readability
+        raise AssertionError("expected RuntimeError")

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -452,11 +452,11 @@ class NetworkError(Exception):
     pass
 
 
-class TimedOut(Exception):
+class TimedOut(Exception):  # noqa: N818 - mirrors python-telegram-bot exception name
     pass
 
 
-class BadRequest(Exception):
+class BadRequest(Exception):  # noqa: N818 - mirrors python-telegram-bot exception name
     pass
 
 


### PR DESCRIPTION
## Summary

Hardens Telegram bot callback handling and adds a redacted diagnostics report command.

## Changes

- Handles transient Telegram network errors around callback acknowledgements and message edits.
- Ignores Telegram `Message is not modified` no-op edit errors.
- Adds an application-level Telegram error handler.
- Adds `armactl report` for copy-pasteable redacted diagnostics.
- Adds tests for Telegram hardening and report generation.

## Validation

- `git diff --check`
- `ruff check src tests`
- `pytest -q`

## Operational notes

After merging, restart only `armactl-bot.service` so the bot process loads the new code. The Arma Reforger game server does not need to restart for this patch.