### PR TITLE
Improve Telegram callback responsiveness

### DIFF
--- a/src/armactl/telegram_bot.py
+++ b/src/armactl/telegram_bot.py
@@ -62,6 +62,18 @@ BULLET = "\u2022"
 DETAILS = "\U0001F4CB"
 TIME_INPUT_RE = re.compile(r"^\d{1,2}:\d{2}(:\d{2})?$")
 SNAPSHOT_CACHE_TTL_SECONDS = 3.0
+TELEGRAM_CALLBACK_TIMEOUT_SECONDS = 1.0
+TELEGRAM_MESSAGE_TIMEOUT_SECONDS = 3.0
+
+
+def _telegram_timeout_kwargs(timeout: float) -> dict[str, float]:
+    """Return PTB request timeout kwargs for a Telegram API call."""
+    return {
+        "connect_timeout": timeout,
+        "read_timeout": timeout,
+        "write_timeout": timeout,
+        "pool_timeout": timeout,
+    }
 
 
 def admin_chat_allowed(chat_id: int | str, admin_chat_ids: list[str]) -> bool:
@@ -946,7 +958,11 @@ class ArmaCtlTelegramBot:
     ) -> None:
         """Acknowledge a callback without aborting the handler on network blips."""
         try:
-            await query.answer(text=text, show_alert=show_alert)
+            await query.answer(
+                text=text,
+                show_alert=show_alert,
+                **_telegram_timeout_kwargs(TELEGRAM_CALLBACK_TIMEOUT_SECONDS),
+            )
         except Exception as error:
             if _is_telegram_network_error(error):
                 LOGGER.warning(
@@ -956,11 +972,24 @@ class ArmaCtlTelegramBot:
                 return
             raise
 
+    def _schedule_callback_answer(self, context, query) -> None:
+        """Acknowledge a callback in the background so UI rendering is not blocked."""
+        coroutine = self._safe_answer_callback(query)
+        application = getattr(context, "application", None)
+        if application is not None and hasattr(application, "create_task"):
+            application.create_task(coroutine)
+            return
+        asyncio.create_task(coroutine)
+
     async def _safe_edit_message_text(self, query, text: str, markup) -> None:
         """Edit a callback message while tolerating no-op edits and network blips."""
         for attempt in range(2):
             try:
-                await query.edit_message_text(text=text, reply_markup=markup)
+                await query.edit_message_text(
+                    text=text,
+                    reply_markup=markup,
+                    **_telegram_timeout_kwargs(TELEGRAM_MESSAGE_TIMEOUT_SECONDS),
+                )
                 return
             except Exception as error:
                 if _is_message_not_modified_error(error):
@@ -980,7 +1009,11 @@ class ArmaCtlTelegramBot:
     async def _safe_reply_text(self, message, text: str, markup=None) -> None:
         """Send a text reply while logging transient Telegram network failures."""
         try:
-            await message.reply_text(text, reply_markup=markup)
+            await message.reply_text(
+                text,
+                reply_markup=markup,
+                **_telegram_timeout_kwargs(TELEGRAM_MESSAGE_TIMEOUT_SECONDS),
+            )
         except Exception as error:
             if _is_telegram_network_error(error):
                 LOGGER.warning(
@@ -1142,7 +1175,7 @@ class ArmaCtlTelegramBot:
             return
 
         query = update.callback_query
-        await self._safe_answer_callback(query)
+        self._schedule_callback_answer(context, query)
         data = query.data or ""
         if data != "schedule:edit":
             self._clear_pending_schedule_input(update)

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -508,6 +508,75 @@ def test_safe_edit_message_text_retries_transient_network_error():
     assert query.calls == 2
 
 
+def test_safe_answer_callback_uses_short_timeouts():
+    import asyncio
+
+    bot = _test_bot()
+    captured = {}
+
+    class Query:
+        async def answer(self, **kwargs):
+            captured.update(kwargs)
+
+    asyncio.run(bot._safe_answer_callback(Query()))
+
+    assert captured["connect_timeout"] == telegram_bot.TELEGRAM_CALLBACK_TIMEOUT_SECONDS
+    assert captured["read_timeout"] == telegram_bot.TELEGRAM_CALLBACK_TIMEOUT_SECONDS
+    assert captured["write_timeout"] == telegram_bot.TELEGRAM_CALLBACK_TIMEOUT_SECONDS
+    assert captured["pool_timeout"] == telegram_bot.TELEGRAM_CALLBACK_TIMEOUT_SECONDS
+
+
+def test_callback_handler_does_not_wait_for_callback_answer():
+    import asyncio
+
+    bot = _test_bot()
+    events = []
+
+    class Query:
+        data = "metrics"
+
+        async def answer(self, **kwargs):
+            events.append("answer-start")
+            await asyncio.sleep(0.05)
+            events.append("answer-end")
+
+    class Application:
+        def __init__(self):
+            self.tasks = []
+
+        def create_task(self, coroutine):
+            task = asyncio.create_task(coroutine)
+            self.tasks.append(task)
+            return task
+
+    async def ensure_allowed(update):
+        return True
+
+    async def reply_with_menu(update, text, markup=None):
+        events.append(("reply", text, markup))
+
+    bot._ensure_allowed = ensure_allowed
+    bot._reply_with_menu = reply_with_menu
+    bot._metrics_text = lambda: "metrics text"
+
+    update = types.SimpleNamespace(
+        callback_query=Query(),
+        effective_chat=types.SimpleNamespace(id=1),
+    )
+    application = Application()
+    context = types.SimpleNamespace(application=application)
+
+    async def run_handler():
+        await bot.callback_handler(update, context)
+        assert ("reply", "metrics text", None) in events
+        assert "answer-end" not in events
+        await asyncio.gather(*application.tasks)
+
+    asyncio.run(run_handler())
+
+    assert "answer-end" in events
+
+
 def test_safe_edit_message_text_reraises_unknown_errors():
     import asyncio
 


### PR DESCRIPTION
## Summary

Improves Telegram bot responsiveness when Telegram API callback acknowledgements are slow or temporarily failing.

## Changes

- Runs callback acknowledgement in the background instead of blocking button handling.
- Adds short Telegram API timeouts for callback acknowledgements.
- Adds timeouts for Telegram message edit/reply calls.
- Keeps transient Telegram network failures as warnings instead of letting them delay or break normal callback processing.
- Adds tests to verify callback handling does not wait for slow `query.answer()` calls.

## Why

The bot could still feel slow even after handling Telegram network errors, because `callback_handler()` waited for `query.answer()` before processing actions like Metrics or Refresh Status. When Telegram returned `httpx.ConnectError` / timeout, users could wait several seconds before seeing the updated view.

## Validation

- `git diff --check`
- `ruff check src tests`
- `pytest -q`

## Operational notes

After merging, restart only the Telegram bot service:

```bash
sudo systemctl restart armactl-bot.service
```

The Arma Reforger game server does not need to restart for this change.