### PR TITLE
Reduce RCON roster latency

### DIFF
--- a/src/armactl/rcon.py
+++ b/src/armactl/rcon.py
@@ -24,6 +24,7 @@ RCON_NOISE_PREFIXES = (
     "logged in! client id:",
     "processing command:",
 )
+RCON_ROSTER_TIMEOUT_SECONDS = 1.5
 
 PLAYER_SLOT_SUFFIX_RE = re.compile(r"\s*\(#(?P<player_id>\d+)\)\s*$")
 GUID_LIKE_RE = re.compile(r"^[0-9a-fA-F-]{8,}$")
@@ -256,7 +257,6 @@ class _RconSession:
             return f"{command_text}\n{server_text}".strip()
         return command_text
 
-
     def logout(self) -> None:
         try:
             self.send_command("@logout")
@@ -307,7 +307,6 @@ def _parse_player_lines(response: str) -> list[PlayerEntry]:
     return entries
 
 
-
 def _query_player_entries(session: _RconSession) -> list[PlayerEntry]:
     """Try the most likely roster commands and return the first non-empty parse."""
     last_error: str = ""
@@ -329,7 +328,10 @@ def _query_player_entries(session: _RconSession) -> list[PlayerEntry]:
     return []
 
 
-def query_player_roster(instance: str, timeout: float = 5.0) -> PlayerRoster:
+def query_player_roster(
+    instance: str,
+    timeout: float = RCON_ROSTER_TIMEOUT_SECONDS,
+) -> PlayerRoster:
     """Return a best-effort player roster using configured local RCON."""
     state = discover(instance, save=False)
     host = "127.0.0.1"

--- a/tests/test_rcon.py
+++ b/tests/test_rcon.py
@@ -218,3 +218,90 @@ def test_query_player_roster_falls_back_to_plain_players_command() -> None:
 
     assert roster.available is True
     assert [entry.name for entry in roster.entries] == ["Denis", "Vova"]
+
+
+def test_query_player_roster_uses_short_default_timeout() -> None:
+    state = ServerState(
+        server_running=True,
+        config_exists=True,
+        config_path="/tmp/config.json",
+        ports=PortInfo(rcon=20000),
+    )
+    config = {
+        "rcon": {
+            "address": "127.0.0.1",
+            "port": 20000,
+            "password": "secret",
+        }
+    }
+    captured: dict[str, float] = {}
+
+    class FakeSession:
+        def __init__(self, host: str, port: int, password: str, timeout: float):
+            captured["timeout"] = timeout
+
+        def login(self) -> None:
+            pass
+
+        def send_command(self, command: str) -> str:
+            return "1 Alice" if command == "#players" else ""
+
+        def logout(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    with (
+        patch("armactl.rcon.discover", return_value=state),
+        patch("armactl.rcon.load_config", return_value=config),
+        patch("armactl.rcon._RconSession", FakeSession),
+    ):
+        roster = rcon.query_player_roster("default")
+
+    assert captured["timeout"] == rcon.RCON_ROSTER_TIMEOUT_SECONDS
+    assert captured["timeout"] == 1.5
+    assert roster.available is True
+    assert [entry.name for entry in roster.entries] == ["Alice"]
+
+
+def test_query_player_roster_allows_explicit_timeout_override() -> None:
+    state = ServerState(
+        server_running=True,
+        config_exists=True,
+        config_path="/tmp/config.json",
+        ports=PortInfo(rcon=20000),
+    )
+    config = {
+        "rcon": {
+            "address": "127.0.0.1",
+            "port": 20000,
+            "password": "secret",
+        }
+    }
+    captured: dict[str, float] = {}
+
+    class FakeSession:
+        def __init__(self, host: str, port: int, password: str, timeout: float):
+            captured["timeout"] = timeout
+
+        def login(self) -> None:
+            pass
+
+        def send_command(self, command: str) -> str:
+            return ""
+
+        def logout(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    with (
+        patch("armactl.rcon.discover", return_value=state),
+        patch("armactl.rcon.load_config", return_value=config),
+        patch("armactl.rcon._RconSession", FakeSession),
+    ):
+        rcon.query_player_roster("default", timeout=0.25)
+
+    assert captured["timeout"] == 0.25


### PR DESCRIPTION
## Summary

Reduces UI latency caused by slow or non-responsive RCON player roster queries.

## Changes

- Adds `RCON_ROSTER_TIMEOUT_SECONDS = 1.5`.
- Changes `query_player_roster()` default timeout from 5.0s to 1.5s.
- Keeps explicit timeout override support.
- Adds focused tests for default roster timeout and explicit timeout overrides.

## Why

Live diagnostics showed `query_player_roster()` taking about 5 seconds when RCON roster output was slow or unavailable. This can make Telegram Players and related UI paths feel unresponsive.

A2S player count remains the primary fast player-count source; RCON roster remains best-effort.

## Validation

- `git diff --check`
- `ruff check src tests`
- `pytest -q`

Local validation on server:

- `ruff`: passed
- `pytest`: `217 passed`

## Operational notes

After merging, restart only the Telegram bot service:

```bash
sudo systemctl restart armactl-bot.service
```

The Arma Reforger game server does not need to restart.