### PR TITLE
Tune Telegram polling timeouts

### DIFF
--- a/src/armactl/telegram_bot.py
+++ b/src/armactl/telegram_bot.py
@@ -64,6 +64,12 @@ TIME_INPUT_RE = re.compile(r"^\d{1,2}:\d{2}(:\d{2})?$")
 SNAPSHOT_CACHE_TTL_SECONDS = 3.0
 TELEGRAM_CALLBACK_TIMEOUT_SECONDS = 1.0
 TELEGRAM_MESSAGE_TIMEOUT_SECONDS = 3.0
+TELEGRAM_API_TIMEOUT_SECONDS = 3.0
+TELEGRAM_GET_UPDATES_CONNECT_TIMEOUT_SECONDS = 3.0
+TELEGRAM_GET_UPDATES_READ_TIMEOUT_SECONDS = 35.0
+TELEGRAM_GET_UPDATES_WRITE_TIMEOUT_SECONDS = 3.0
+TELEGRAM_GET_UPDATES_POOL_TIMEOUT_SECONDS = 3.0
+TELEGRAM_GET_UPDATES_POLL_TIMEOUT_SECONDS = 30
 
 
 def _telegram_timeout_kwargs(timeout: float) -> dict[str, float]:
@@ -1350,7 +1356,23 @@ class ArmaCtlTelegramBot:
         )
         logging.getLogger("httpx").setLevel(logging.WARNING)
 
-        application = Application.builder().token(self.config.token).build()
+        application = (
+            Application.builder()
+            .token(self.config.token)
+            .connect_timeout(TELEGRAM_API_TIMEOUT_SECONDS)
+            .read_timeout(TELEGRAM_API_TIMEOUT_SECONDS)
+            .write_timeout(TELEGRAM_API_TIMEOUT_SECONDS)
+            .pool_timeout(TELEGRAM_API_TIMEOUT_SECONDS)
+            .get_updates_connect_timeout(
+                TELEGRAM_GET_UPDATES_CONNECT_TIMEOUT_SECONDS
+            )
+            .get_updates_read_timeout(TELEGRAM_GET_UPDATES_READ_TIMEOUT_SECONDS)
+            .get_updates_write_timeout(
+                TELEGRAM_GET_UPDATES_WRITE_TIMEOUT_SECONDS
+            )
+            .get_updates_pool_timeout(TELEGRAM_GET_UPDATES_POOL_TIMEOUT_SECONDS)
+            .build()
+        )
         application.add_handler(CommandHandler("start", self.start_command))
         application.add_handler(CommandHandler("status", self.status_command))
         application.add_handler(CommandHandler("stop", self.stop_command))
@@ -1361,7 +1383,10 @@ class ArmaCtlTelegramBot:
         )
         application.add_handler(CallbackQueryHandler(self.callback_handler))
         application.add_error_handler(self.error_handler)
-        application.run_polling(allowed_updates=Update.ALL_TYPES)
+        application.run_polling(
+            allowed_updates=Update.ALL_TYPES,
+            timeout=TELEGRAM_GET_UPDATES_POLL_TIMEOUT_SECONDS,
+        )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -592,3 +592,97 @@ def test_safe_edit_message_text_reraises_unknown_errors():
         assert "unexpected failure" in str(error)
     else:  # pragma: no cover - explicit assertion path for readability
         raise AssertionError("expected RuntimeError")
+
+
+def test_build_application_configures_telegram_request_timeouts():
+    bot = _test_bot()
+    captured: dict[str, object] = {}
+
+    class FakeBuilder:
+        def token(self, value):
+            captured["token"] = value
+            return self
+
+        def connect_timeout(self, value):
+            captured["connect_timeout"] = value
+            return self
+
+        def read_timeout(self, value):
+            captured["read_timeout"] = value
+            return self
+
+        def write_timeout(self, value):
+            captured["write_timeout"] = value
+            return self
+
+        def pool_timeout(self, value):
+            captured["pool_timeout"] = value
+            return self
+
+        def get_updates_connect_timeout(self, value):
+            captured["get_updates_connect_timeout"] = value
+            return self
+
+        def get_updates_read_timeout(self, value):
+            captured["get_updates_read_timeout"] = value
+            return self
+
+        def get_updates_write_timeout(self, value):
+            captured["get_updates_write_timeout"] = value
+            return self
+
+        def get_updates_pool_timeout(self, value):
+            captured["get_updates_pool_timeout"] = value
+            return self
+
+        def build(self):
+            return fake_application
+
+    class FakeApplication:
+        def __init__(self):
+            self.handlers = []
+            self.error_handlers = []
+            self.polling_kwargs = None
+
+        def add_handler(self, handler):
+            self.handlers.append(handler)
+
+        def add_error_handler(self, handler):
+            self.error_handlers.append(handler)
+
+        def run_polling(self, **kwargs):
+            self.polling_kwargs = kwargs
+
+    fake_application = FakeApplication()
+    fake_builder = FakeBuilder()
+
+    with mock.patch("telegram.ext.Application.builder", return_value=fake_builder):
+        bot.build_application()
+
+    assert captured["token"] == "token"
+    assert captured["connect_timeout"] == telegram_bot.TELEGRAM_API_TIMEOUT_SECONDS
+    assert captured["read_timeout"] == telegram_bot.TELEGRAM_API_TIMEOUT_SECONDS
+    assert captured["write_timeout"] == telegram_bot.TELEGRAM_API_TIMEOUT_SECONDS
+    assert captured["pool_timeout"] == telegram_bot.TELEGRAM_API_TIMEOUT_SECONDS
+    assert (
+        captured["get_updates_connect_timeout"]
+        == telegram_bot.TELEGRAM_GET_UPDATES_CONNECT_TIMEOUT_SECONDS
+    )
+    assert (
+        captured["get_updates_read_timeout"]
+        == telegram_bot.TELEGRAM_GET_UPDATES_READ_TIMEOUT_SECONDS
+    )
+    assert (
+        captured["get_updates_write_timeout"]
+        == telegram_bot.TELEGRAM_GET_UPDATES_WRITE_TIMEOUT_SECONDS
+    )
+    assert (
+        captured["get_updates_pool_timeout"]
+        == telegram_bot.TELEGRAM_GET_UPDATES_POOL_TIMEOUT_SECONDS
+    )
+    assert (
+        fake_application.polling_kwargs["timeout"]
+        == telegram_bot.TELEGRAM_GET_UPDATES_POLL_TIMEOUT_SECONDS
+    )
+    assert fake_application.handlers
+    assert fake_application.error_handlers == [bot.error_handler]


### PR DESCRIPTION
## Summary

Tunes Telegram bot request and long-polling timeouts for more predictable runtime behavior.

## Changes

- Adds explicit Telegram API timeout constants.
- Configures normal bot API request timeouts through `ApplicationBuilder`.
- Configures `getUpdates` timeout settings separately for long polling.
- Sets `run_polling(timeout=30)` with a longer `get_updates_read_timeout=35`.
- Adds tests for Telegram `ApplicationBuilder` timeout configuration.

## Why

Live logs showed intermittent Telegram `get_updates` timeout/network warnings even though direct `curl` and `httpx` checks to `api.telegram.org` were fast and stable.

`python-telegram-bot` also explicitly recommended configuring `ApplicationBuilder` / `get_updates_request` timeout settings for this case.

## Validation

- `git diff --check`
- `ruff check src tests`
- `pytest -q`

## Operational notes

After merging, restart only the Telegram bot service:

```bash
sudo systemctl restart armactl-bot.service
```

The Arma Reforger game server does not need to restart.