### PR TITLE
Handle stale Telegram callbacks

### DIFF
--- a/src/armactl/telegram_bot.py
+++ b/src/armactl/telegram_bot.py
@@ -115,6 +115,15 @@ def _is_message_not_modified_error(error: BaseException) -> bool:
     )
 
 
+def _is_stale_callback_query_error(error: BaseException) -> bool:
+    """Return whether Telegram rejected an expired callback query answer."""
+    return (
+        _telegram_error_name(error) == "BadRequest"
+        and "Query is too old and response timeout expired or query id is invalid"
+        in str(error)
+    )
+
+
 @dataclass
 class BotStatusSnapshot:
     """Small, test-friendly status payload for rendering bot responses."""
@@ -970,6 +979,9 @@ class ArmaCtlTelegramBot:
                 **_telegram_timeout_kwargs(TELEGRAM_CALLBACK_TIMEOUT_SECONDS),
             )
         except Exception as error:
+            if _is_stale_callback_query_error(error):
+                LOGGER.debug("Telegram callback answer skipped: stale callback query")
+                return
             if _is_telegram_network_error(error):
                 LOGGER.warning(
                     "Telegram callback answer failed: %s",
@@ -1326,6 +1338,9 @@ class ArmaCtlTelegramBot:
         if _is_message_not_modified_error(error):
             LOGGER.debug("Telegram update skipped: message is not modified")
             return
+        if _is_stale_callback_query_error(error):
+            LOGGER.debug("Telegram update skipped: stale callback query")
+            return
         if _is_telegram_network_error(error):
             LOGGER.warning("Telegram network error: %s", redact_sensitive_text(error))
             return
@@ -1386,6 +1401,7 @@ class ArmaCtlTelegramBot:
         application.run_polling(
             allowed_updates=Update.ALL_TYPES,
             timeout=TELEGRAM_GET_UPDATES_POLL_TIMEOUT_SECONDS,
+            drop_pending_updates=True,
         )
 
 

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -472,6 +472,33 @@ def test_safe_answer_callback_ignores_telegram_network_errors():
     asyncio.run(bot._safe_answer_callback(Query()))
 
 
+def test_safe_answer_callback_ignores_stale_callback_query():
+    import asyncio
+
+    bot = _test_bot()
+
+    class Query:
+        async def answer(self, **kwargs):
+            raise BadRequest(
+                "Query is too old and response timeout expired or query id is invalid"
+            )
+
+    asyncio.run(bot._safe_answer_callback(Query()))
+
+
+def test_error_handler_ignores_stale_callback_query():
+    import asyncio
+
+    bot = _test_bot()
+    context = types.SimpleNamespace(
+        error=BadRequest(
+            "Query is too old and response timeout expired or query id is invalid"
+        )
+    )
+
+    asyncio.run(bot.error_handler(None, context))
+
+
 def test_safe_edit_message_text_ignores_message_not_modified():
     import asyncio
 
@@ -684,5 +711,6 @@ def test_build_application_configures_telegram_request_timeouts():
         fake_application.polling_kwargs["timeout"]
         == telegram_bot.TELEGRAM_GET_UPDATES_POLL_TIMEOUT_SECONDS
     )
+    assert fake_application.polling_kwargs["drop_pending_updates"] is True
     assert fake_application.handlers
     assert fake_application.error_handlers == [bot.error_handler]


### PR DESCRIPTION
## Summary

Handles expired Telegram callback query acknowledgements as benign and drops pending updates on bot startup.

## Changes

- Treats stale callback query `BadRequest` errors as non-fatal.
- Prevents stale callback answer failures from becoming noisy handler errors.
- Adds `drop_pending_updates=True` to `run_polling()`.
- Adds focused tests for stale callback answer handling and polling startup configuration.

## Why

Live logs showed Telegram callbacks being processed after Telegram's callback query deadline:

```text
Query is too old and response timeout expired or query id is invalid
```

This can happen after restarts or delayed queued updates. These stale callback acknowledgements should not be reported as real bot failures.

Validation

```bash
git diff --check
ruff check src tests
pytest -q
```
Operational notes

After merging, restart only the Telegram bot service:

```bash
sudo systemctl restart armactl-bot.service
```

The Arma Reforger game server does not need to restart.