### PR TITLE
Prepare v0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Semantic Versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-05-15
+
+### Fixed
+- Improved Telegram inline button responsiveness after idle periods by shortening `getUpdates` polling/read windows.
+- Reduced Telegram status snapshot stalls by using a shorter Telegram-only A2S player-status timeout.
+- Retried transient Telegram callback acknowledgement network failures.
+- Treated stale Telegram callback acknowledgements as benign during delayed or restarted polling.
+- Reduced RCON player roster latency for Players views.
+
+### Changed
+- Hardened Telegram API timeout handling for callback answers, message edits, replies, and polling.
+- Dropped pending Telegram updates on bot startup to avoid processing stale callback queues.
+
+### Added
+- Added redacted `armactl report` diagnostics for troubleshooting bot/server state.
+
 ## [0.5.0] - 2026-05-15
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "armactl"
-version = "0.5.0"
+version = "0.5.1"
 description = "Installer, manager and TUI for Arma Reforger Dedicated Server on Linux"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bumped package version from `0.5.0` to `0.5.1`.
- Added `0.5.1` release notes to `CHANGELOG.md`.
- Summarized Telegram/RCON responsiveness and diagnostics fixes merged after `0.5.0`.

This release is needed to ship the Telegram button latency fixes, stale callback handling, polling timeout tuning, callback acknowledgement retry, shorter Telegram-only A2S timeout, and RCON roster latency reduction as a patch release.

## Related issue

Closes #

## Validation

- [ ] `./scripts/run-host-tests`
- [x] `python3 -m pytest -q` — 221 passed
- [x] `python3 -m ruff check src tests`
- [x] Relevant manual flow tested
- [ ] TUI flow tested, if this PR changes Textual screens or user interaction
- [x] The changed files are relevant to the linked issue
- [x] This PR does not introduce unrelated changes

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [ ] systemd / timer
- [ ] config.json handling
- [ ] Mods / addon cleanup
- [ ] TUI / UX / Textual screens
- [x] Telegram bot
- [x] Release / versioning
- [ ] docs only

## Automated contribution disclosure

- [x] This PR was written or substantially reviewed by a human maintainer/contributor
- [x] This is not a low-effort automated bounty submission
- [x] If AI or automation was used, the generated changes were manually reviewed

## Notes

- No migration is required.
- Operator-facing impact: after merging/releasing, restart only `armactl-bot.service` so the Telegram bot loads the new code.
- The Arma Reforger game server does not need to restart for this patch release.
- Rollback: install/use the previous `v0.5.0` package or checkout the previous release tag.