### PR TITLE
docs: update release readiness checklist

### DIFF
--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -226,8 +226,9 @@
 - [x] Додати changelog
 - [x] Перевірити Server FPS telemetry на live сервері
 - [x] Перевірити `./armactl status` після merge в `main`
-- [ ] Підготувати GitHub release `v0.5.0`
-- [ ] Підготувати перший GitHub release
+- [x] Підготувати GitHub release `v0.5.0`
+- [x] Підготувати перший GitHub release
+- [x] Підготувати patch release `v0.5.1`
 - [ ] Перевірити встановлення з релізного архіву
 - [ ] Перевірити запуск на іншій машині
 


### PR DESCRIPTION
## Summary

- Mark the first GitHub release and `v0.5.0` release checklist items as completed.
- Add the completed `v0.5.1` patch release to the release readiness checklist.
- Keep release archive install and another-machine smoke test as remaining unchecked follow-ups.

This was needed because GitHub releases now exist and the checklist still reflected pre-release state.

## Related issue

Closes #26

## Validation

- [ ] `./scripts/run-host-tests`
- [ ] `python3 -m pytest -q`
- [ ] `python3 -m ruff check src tests`
- [x] Relevant manual flow tested
- [ ] TUI flow tested, if this PR changes Textual screens or user interaction
- [x] The changed files are relevant to the linked issue
- [x] This PR does not introduce unrelated changes

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [ ] systemd / timer
- [ ] config.json handling
- [ ] Mods / addon cleanup
- [ ] TUI / UX / Textual screens
- [ ] Telegram bot
- [x] Release / versioning
- [x] docs only

## Automated contribution disclosure

- [x] This PR was written or substantially reviewed by a human maintainer/contributor
- [x] This is not a low-effort automated bounty submission
- [x] If AI or automation was used, the generated changes were manually reviewed

## Notes

- No migration or operator-facing runtime change.
- This is docs-only checklist cleanup after `v0.5.0` and `v0.5.1` were published.