### PR TITLE
sync-generated update

### DIFF
--- a/src/armactl/cli.py
+++ b/src/armactl/cli.py
@@ -149,6 +149,38 @@ def status(ctx: click.Context) -> None:
         )
 
 
+@main.command("sync-generated")
+@click.pass_context
+def sync_generated(ctx: click.Context) -> None:
+    """Refresh generated runtime files without stopping the server."""
+    from armactl.service_manager import sync_generated_start_script
+
+    instance = ctx.obj["instance"]
+    state = _get_state(ctx)
+
+    if not state.server_installed:
+        if ctx.obj["json"]:
+            click.echo(json.dumps({"error": "no_server_found"}))
+        else:
+            click.echo(f"[{instance}] No server found.", err=True)
+        sys.exit(1)
+
+    result = sync_generated_start_script(instance)
+
+    if ctx.obj["json"]:
+        click.echo(json.dumps(result.to_dict(), indent=2))
+    else:
+        prefix = "✓" if result.success else "✗"
+        click.echo(f"[{instance}] {prefix} {result.message}")
+        if result.success and state.server_running:
+            click.echo(
+                f"[{instance}] Restart the server when convenient to apply "
+                "launch script changes."
+            )
+
+    sys.exit(0 if result.success else 1)
+
+
 @main.command()
 @click.pass_context
 def start(ctx: click.Context) -> None:

--- a/src/armactl/locales/uk.json
+++ b/src/armactl/locales/uk.json
@@ -508,6 +508,13 @@
     "Mod pack imported, but local addon cleanup failed: {error}": "Модпак імпортовано, але очищення локальних аддонів не вдалося: {error}",
     "Removed mod {mod_id} and deleted {count} local addon directory/directories: {size} freed.": "Мод {mod_id} видалено й очищено {count} локальних аддон-директорій: звільнено {size}.",
     "Failed to save config after freeing addon files for removed mods: {error}": "Не вдалося зберегти конфіг після звільнення місця файлами видалених модів: {error}",
-    "Removed mod {mod_id}. No local addon files found.": "Мод {mod_id} видалено. Локальних аддон-файлів не знайдено."
+    "Removed mod {mod_id}. No local addon files found.": "Мод {mod_id} видалено. Локальних аддон-файлів не знайдено.",
+    "Failed to read generated start script {path}: {error}": "Не вдалося прочитати згенерований стартовий скрипт {path}: {error}",
+    "Generated Files": "Згенеровані файли",
+    "Generated start script is up to date: {path}": "Згенерований стартовий скрипт актуальний: {path}",
+    "Generated start script sync failed: {error}": "Не вдалося синхронізувати згенерований стартовий скрипт: {error}",
+    "Instance root not found: {path}": "Кореневу директорію інстанса не знайдено: {path}",
+    "Updated generated start script:": "Оновлено згенерований стартовий скрипт:",
+    "Updated generated start script: {path}. Restart the server to apply launch changes.": "Оновлено згенерований стартовий скрипт: {path}. Перезапустіть сервер, щоб застосувати зміни запуску."
   }
 }

--- a/src/armactl/service_manager.py
+++ b/src/armactl/service_manager.py
@@ -259,6 +259,120 @@ def _normalize_generated_text(text: str) -> str:
     return normalized if normalized.endswith("\n") else f"{normalized}\n"
 
 
+def render_start_script(
+    *,
+    instance_root: Path | str,
+    server_dir: Path | str,
+    config_dir: Path | str,
+    config_file: Path | str,
+    log_stats_interval_ms: int = 10000,
+    max_fps: int = 60,
+) -> str:
+    """Render the generated Arma Reforger launch script from the current template."""
+    env = _template_environment()
+    rendered = env.get_template("start-armareforger.sh.j2").render(
+        instance_root=str(instance_root),
+        server_dir=str(server_dir),
+        config_dir=str(config_dir),
+        config_file=str(config_file),
+        log_stats_interval_ms=log_stats_interval_ms,
+        max_fps=max_fps,
+    )
+    return _normalize_generated_text(rendered)
+
+
+def sync_generated_start_script(
+    instance: str = paths.DEFAULT_INSTANCE_NAME,
+) -> ServiceResult:
+    """Refresh the per-instance generated start script without touching services.
+
+    This is intentionally lighter than repair:
+    - no SteamCMD validate
+    - no service stop/start
+    - no systemd unit installation
+    - safe to run while the server is online
+
+    The refreshed script takes effect on the next service restart.
+    """
+    try:
+        server_dir = paths.validate_server_install_dir(
+            paths.server_dir(instance),
+            instance=instance,
+        )
+        instance_root = server_dir.parent
+        config_dir = paths.config_dir(instance)
+        config_file = paths.config_file(instance)
+        start_sh = paths.start_script(instance)
+
+        if not instance_root.exists():
+            return ServiceResult(
+                False,
+                tr("Instance root not found: {path}", path=instance_root),
+                1,
+            )
+
+        rendered = render_start_script(
+            instance_root=instance_root,
+            server_dir=server_dir,
+            config_dir=config_dir,
+            config_file=config_file,
+            log_stats_interval_ms=10000,
+            max_fps=60,
+        )
+
+        try:
+            current = start_sh.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            current = ""
+        except OSError as error:
+            return ServiceResult(
+                False,
+                tr(
+                    "Failed to read generated start script {path}: {error}",
+                    path=start_sh,
+                    error=redact_sensitive_text(error),
+                ),
+                1,
+            )
+
+        if current == rendered:
+            try:
+                start_sh.chmod(0o755)
+            except OSError:
+                pass
+            return ServiceResult(
+                True,
+                tr("Generated start script is up to date: {path}", path=start_sh),
+            )
+
+        start_sh.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = start_sh.with_name(f".{start_sh.name}.tmp")
+        temp_path.write_text(rendered, encoding="utf-8")
+        temp_path.chmod(0o755)
+        temp_path.replace(start_sh)
+        start_sh.chmod(0o755)
+
+        return ServiceResult(
+            True,
+            tr(
+                "Updated generated start script: {path}. "
+                "Restart the server to apply launch changes.",
+                path=start_sh,
+            ),
+        )
+    except paths.UnsafeServerInstallDirError as error:
+        return ServiceResult(False, str(error), 1)
+    except OSError as error:
+        return ServiceResult(
+            False,
+            tr(
+                "Generated start script sync failed: {error}",
+                error=redact_sensitive_text(error),
+            ),
+            1,
+        )
+
+
 def _render_privileged_helper_script() -> str:
     """Render the root-owned helper script text."""
     env = _template_environment()
@@ -947,11 +1061,11 @@ def generate_services(
 
     # 2. Render templates
     try:
-        start_sh_render = env.get_template("start-armareforger.sh.j2").render(
-            instance_root=str(inst_root),
-            server_dir=str(server_dir),
-            config_dir=str(config_dir),
-            config_file=str(config_file),
+        start_sh_render = render_start_script(
+            instance_root=inst_root,
+            server_dir=server_dir,
+            config_dir=config_dir,
+            config_file=config_file,
             log_stats_interval_ms=10000,
             max_fps=60,
         )

--- a/src/armactl/tui/app.py
+++ b/src/armactl/tui/app.py
@@ -19,6 +19,7 @@ from armactl import paths
 from armactl.bot_manager import ensure_bot_service_runtime
 from armactl.discovery import discover
 from armactl.i18n import _, get_current_lang_name, toggle_lang, tr
+from armactl.service_manager import sync_generated_start_script
 from armactl.state import ServerState
 from armactl.tui.display import get_instance_server_name
 
@@ -327,10 +328,13 @@ class ArmaCtlApp(App):
         self._main_menu_actions: HorizontalScroll | None = None
         self._main_menu_content: VerticalScroll | None = None
         self._main_menu_refresh_lock = Lock()
+        self._generated_sync_notification_shown = False
 
     def on_mount(self) -> None:
         """Kick off small background health checks once the main menu is shown."""
-        self._update_main_menu_header(discover(instance=self.instance, save=False))
+        state = discover(instance=self.instance, save=False)
+        self._sync_generated_runtime_files(state)
+        self._update_main_menu_header(state)
         self.ensure_bot_runtime_task()
 
     @work(exclusive=True, thread=True)
@@ -355,6 +359,30 @@ class ArmaCtlApp(App):
             _("Recovered Telegram bot service automatically after host boot."),
             title=_("Telegram Bot"),
         )
+
+    def _sync_generated_runtime_files(self, state: ServerState) -> None:
+        """Keep generated per-instance launch files in sync with current templates."""
+        if not state.server_installed:
+            return
+
+        result = sync_generated_start_script(self.instance)
+        if not result.success:
+            if not self._generated_sync_notification_shown:
+                self._generated_sync_notification_shown = True
+                self.notify(
+                    result.message,
+                    title=_("Generated Files"),
+                    severity="warning",
+                )
+            return
+
+        if result.message.startswith(_("Updated generated start script:")):
+            self._generated_sync_notification_shown = True
+            self.notify(
+                result.message,
+                title=_("Generated Files"),
+                severity="warning",
+            )
 
     def _main_menu_buttons(self, state: ServerState) -> list[Button]:
         """Build the current root action bar buttons."""
@@ -478,6 +506,7 @@ class ArmaCtlApp(App):
         """Re-run discovery and rebuild the root menu without duplicate widget IDs."""
         async with self._main_menu_refresh_lock:
             state = discover(instance=self.instance, save=save)
+            self._sync_generated_runtime_files(state)
             if self._main_menu_actions is None or self._main_menu_content is None:
                 return state
 

--- a/tests/test_service_integration.py
+++ b/tests/test_service_integration.py
@@ -115,3 +115,53 @@ def test_update_restart_timer_schedule_without_helper_installs_rendered_timer(
     assert "OnCalendar=*-*-* 18:00:00" in captured["content"]
     assert [result.success for result in results] == [True, True, True]
     restart_timer_mock.assert_called_once_with("restart", "armareforger-restart@alpha.timer")
+
+
+def test_sync_generated_start_script_refreshes_stale_runtime_script(tmp_path: Path) -> None:
+    instance = "alpha"
+    instance_root = tmp_path / "armactl-data" / instance
+    server_dir = instance_root / "server"
+    config_dir = instance_root / "config"
+    config_file = config_dir / "config.json"
+    start_script_path = instance_root / "start-armareforger.sh"
+
+    server_dir.mkdir(parents=True)
+    config_dir.mkdir(parents=True)
+    config_file.write_text("{}", encoding="utf-8")
+    start_script_path.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+
+INSTANCE_ROOT="/old"
+SERVER_DIR="${INSTANCE_ROOT}/server"
+CONFIG_DIR="${INSTANCE_ROOT}/config"
+CONFIG_FILE="${CONFIG_DIR}/config.json"
+PROFILE_DIR="${SERVER_DIR}/profile"
+
+exec "${SERVER_DIR}/ArmaReforgerServer" \
+  -config "${CONFIG_FILE}" \
+  -profile "${PROFILE_DIR}" \
+  -logStats 10000 \
+  -maxFPS 60
+""",
+        encoding="utf-8",
+    )
+    start_script_path.chmod(0o644)
+
+    with (
+        patch("armactl.service_manager.paths.server_dir", return_value=server_dir),
+        patch("armactl.service_manager.paths.config_dir", return_value=config_dir),
+        patch("armactl.service_manager.paths.config_file", return_value=config_file),
+        patch("armactl.service_manager.paths.start_script", return_value=start_script_path),
+    ):
+        result = service_manager.sync_generated_start_script(instance)
+
+    start_script_text = start_script_path.read_text(encoding="utf-8")
+    assert result.success is True
+    assert "Updated generated start script" in result.message
+    assert "PROFILE_DIR=" not in start_script_text
+    assert f'CONFIG_DIR="{config_dir}"' in start_script_text
+    assert '-profile "${CONFIG_DIR}"' in start_script_text
+    assert "-logStats 10000" in start_script_text
+    assert start_script_path.stat().st_mode & 0o777 == 0o755
+


### PR DESCRIPTION
## Summary

- What changed?
  - Added lightweight generated runtime file sync for per-instance `start-armareforger.sh`.
  - Added `./armactl sync-generated` CLI command.
  - Added TUI startup/refresh auto-sync for generated runtime files.
  - Refactored start script rendering into `render_start_script()` so service generation and sync use the same template path.
  - Added regression coverage for refreshing stale generated start scripts.

- Why was this needed?
  - `git pull` updates templates in `~/armactl`, but existing generated runtime files in `~/armactl-data/<instance>/` were not updated.
  - Older generated scripts could keep launching the server with `-profile "${SERVER_DIR}/profile"`, while FPS telemetry parsing expects logs under `config/logs`.
  - This caused TUI to show `Server FPS: unavailable` even though `-logStats` was active and FPS telemetry existed under the old profile path.

## Related issue

Closes #

## Validation

- [ ] `./scripts/run-host-tests`
- [x] `python3 -m pytest -q`
- [ ] `python3 -m ruff check src tests`
- [x] Relevant manual flow tested
- [x] TUI flow tested, if this PR changes Textual screens or user interaction
- [x] The changed files are relevant to the linked issue
- [x] This PR does not introduce unrelated changes

## Risk areas

- [x] Install / bootstrap
- [x] Existing server detection
- [x] systemd / timer
- [ ] config.json handling
- [ ] Mods / addon cleanup
- [x] TUI / UX / Textual screens
- [ ] Telegram bot
- [ ] Release / versioning
- [ ] docs only

## Automated contribution disclosure

- [x] This PR was written or substantially reviewed by a human maintainer/contributor
- [x] This is not a low-effort automated bounty submission
- [x] If AI or automation was used, the generated changes were manually reviewed

## Notes

- Existing installations may have stale generated `start-armareforger.sh` files after pulling newer templates.
- `sync-generated` refreshes the generated start script without stopping the server, running SteamCMD, or reinstalling systemd units.
- Updated launch arguments take effect only after the Arma Reforger service is restarted.
- Manual flow tested:
  - Ran `./armactl sync-generated`.
  - Confirmed generated script changed to `-profile "${CONFIG_DIR}"`.
  - Confirmed the command reports that restart is required to apply launch changes.
- TUI implication:
  - On TUI startup/refresh, generated runtime files are synchronized and the user is warned when a restart is needed.