### PR TITLE
show server operational status in TUI

### DIFF
--- a/src/armactl/locales/uk.json
+++ b/src/armactl/locales/uk.json
@@ -515,6 +515,18 @@
     "Generated start script sync failed: {error}": "Не вдалося синхронізувати згенерований стартовий скрипт: {error}",
     "Instance root not found: {path}": "Кореневу директорію інстанса не знайдено: {path}",
     "Updated generated start script:": "Оновлено згенерований стартовий скрипт:",
-    "Updated generated start script: {path}. Restart the server to apply launch changes.": "Оновлено згенерований стартовий скрипт: {path}. Перезапустіть сервер, щоб застосувати зміни запуску."
+    "Updated generated start script: {path}. Restart the server to apply launch changes.": "Оновлено згенерований стартовий скрипт: {path}. Перезапустіть сервер, щоб застосувати зміни запуску.",
+    "[bold cyan]Operational Status[/bold cyan]": "[bold cyan]Операційний стан[/bold cyan]",
+    "Operational: {value}": "Стан: {value}",
+    "Operational status: {value}": "Операційний стан: {value}",
+    "Latest log: {value}": "Останній лог: {value}",
+    "Ready": "Готовий",
+    "Downloading mods": "Завантаження модів",
+    "Downloading mods (retrying)": "Завантаження модів (повторна спроба)",
+    "Mission/config error": "Помилка місії/конфігу",
+    "Starting": "Запускається",
+    "Waiting for server telemetry": "Очікування телеметрії сервера",
+    "Telemetry log unavailable": "Лог телеметрії недоступний",
+    "Telemetry stale": "Телеметрія застаріла"
   }
 }

--- a/src/armactl/metrics.py
+++ b/src/armactl/metrics.py
@@ -58,6 +58,20 @@ class ServerFpsMetrics:
     error: str = ""
 
 
+@dataclass
+class ServerOperationalStatus:
+    """Best-effort lifecycle state parsed from recent server log lines."""
+
+    available: bool
+    state: str = "unknown"
+    severity: str = "info"
+    message: str = "Unknown"
+    details: tuple[str, ...] = ()
+    age_seconds: float | None = None
+    source: str = ""
+    error: str = ""
+
+
 FPS_STATS_RE = re.compile(
     r"FPS:\s*(?P<fps>\d+(?:\.\d+)?),\s*"
     r"frame time\s*\(\s*avg:\s*(?P<frame_avg>\d+(?:\.\d+)?)\s*ms,\s*"
@@ -220,6 +234,176 @@ def query_server_fps_metrics(
         )
     except (IndexError, ValueError) as error:
         return ServerFpsMetrics(False, source=source, error=str(error))
+
+
+OPERATIONAL_STATUS_TAIL_LINES = 300
+
+
+def _tail_recent_log_lines(
+    text: str,
+    max_lines: int = OPERATIONAL_STATUS_TAIL_LINES,
+) -> list[str]:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return lines[-max_lines:]
+
+
+def _line_has_download_retry(line: str) -> bool:
+    return any(
+        marker in line
+        for marker in (
+            "Fragmentizer: Retrying download",
+            "Fragmentizer: Download error",
+            "Curl error=",
+        )
+    )
+
+
+def _line_has_download_progress(line: str) -> bool:
+    return (
+        "Addon Download started" in line
+        or "Download speed" in line
+        or ("Downloading " in line and ("addons" in line or "version" in line))
+        or re.search(r":\s*\[[=>_ ]+\]\s*\d+%", line) is not None
+    )
+
+
+def _line_has_mission_error(line: str) -> bool:
+    return (
+        "MissionHeader::ReadMissionHeader cannot load" in line
+        or "cannot load the resource" in line
+    )
+
+
+def _line_has_starting_status(line: str) -> bool:
+    return any(
+        marker in line
+        for marker in (
+            "Loading dedicated server config",
+            "Game successfully created",
+            "Starting dedicated server",
+        )
+    )
+
+
+def query_server_operational_status(
+    config_dir: str | Path,
+    max_age_seconds: float = 120.0,
+) -> ServerOperationalStatus:
+    """Return a user-facing lifecycle status from the latest console log."""
+    latest_log = _latest_console_log(Path(config_dir))
+    if latest_log is None:
+        return ServerOperationalStatus(
+            False,
+            state="unknown",
+            severity="warning",
+            message="Telemetry log unavailable",
+            error="server console log is not available",
+        )
+
+    source = str(latest_log)
+    try:
+        log_mtime = os.path.getmtime(latest_log)
+        text = latest_log.read_text(encoding="utf-8", errors="replace")
+    except OSError as error:
+        return ServerOperationalStatus(
+            False,
+            state="unknown",
+            severity="warning",
+            message="Telemetry log unavailable",
+            source=source,
+            error=str(error),
+        )
+
+    age_seconds = max(time.time() - log_mtime, 0.0)
+    lines = _tail_recent_log_lines(text)
+    if not lines:
+        return ServerOperationalStatus(
+            False,
+            state="unknown",
+            severity="warning",
+            message="Telemetry log unavailable",
+            age_seconds=age_seconds,
+            source=source,
+            error="server console log is empty",
+        )
+
+    if age_seconds > max_age_seconds:
+        return ServerOperationalStatus(
+            False,
+            state="telemetry_stale",
+            severity="warning",
+            message="Telemetry stale",
+            details=(lines[-1],),
+            age_seconds=age_seconds,
+            source=source,
+            error="server console log is stale",
+        )
+
+    for line in reversed(lines):
+        if FPS_STATS_RE.search(line):
+            return ServerOperationalStatus(
+                True,
+                state="ready",
+                severity="success",
+                message="Ready",
+                details=(line,),
+                age_seconds=age_seconds,
+                source=source,
+            )
+
+        if _line_has_download_retry(line):
+            return ServerOperationalStatus(
+                True,
+                state="downloading_mods",
+                severity="warning",
+                message="Downloading mods (retrying)",
+                details=(line,),
+                age_seconds=age_seconds,
+                source=source,
+            )
+
+        if _line_has_download_progress(line):
+            return ServerOperationalStatus(
+                True,
+                state="downloading_mods",
+                severity="warning",
+                message="Downloading mods",
+                details=(line,),
+                age_seconds=age_seconds,
+                source=source,
+            )
+
+        if _line_has_mission_error(line):
+            return ServerOperationalStatus(
+                True,
+                state="mission_error",
+                severity="error",
+                message="Mission/config error",
+                details=(line,),
+                age_seconds=age_seconds,
+                source=source,
+            )
+
+        if _line_has_starting_status(line):
+            return ServerOperationalStatus(
+                True,
+                state="starting",
+                severity="info",
+                message="Starting",
+                details=(line,),
+                age_seconds=age_seconds,
+                source=source,
+            )
+
+    return ServerOperationalStatus(
+        True,
+        state="waiting_for_telemetry",
+        severity="warning",
+        message="Waiting for server telemetry",
+        details=(lines[-1],),
+        age_seconds=age_seconds,
+        source=source,
+    )
 
 
 def _cpu_count() -> int:

--- a/src/armactl/tui/screens.py
+++ b/src/armactl/tui/screens.py
@@ -54,6 +54,7 @@ from armactl.logs import get_logs_text
 from armactl.metrics import (
     HostMetrics,
     ServerFpsMetrics,
+    ServerOperationalStatus,
     format_bytes,
     format_cpu_percent,
     format_duration,
@@ -62,6 +63,7 @@ from armactl.metrics import (
     format_load_average,
     query_host_metrics,
     query_server_fps_metrics,
+    query_server_operational_status,
     query_service_runtime_metrics,
 )
 from armactl.mods import add_mod, dedupe_mods, remove_mod_detailed
@@ -568,9 +570,19 @@ class ManageScreen(Screen):
 
         btn_toggle.refresh(layout=True)
         enabled_text = self._yes_no(service_status.get("enabled"))
-        status_label.update(
-            f"{status_text}  |  {tr('Service enabled: {value}', value=enabled_text)}"
-        )
+        summary_parts = [
+            status_text,
+            tr("Service enabled: {value}", value=enabled_text),
+        ]
+        if state.server_running:
+            operational_status = self._query_server_operational_status()
+            summary_parts.append(
+                tr(
+                    "Operational: {value}",
+                    value=self._plain_operational_value(operational_status),
+                )
+            )
+        status_label.update("  |  ".join(summary_parts))
         self._render_active_panel()
 
     def _format_players(self, current: int | None, maximum: int | None) -> str:
@@ -602,6 +614,53 @@ class ManageScreen(Screen):
             return query_server_fps_metrics(paths.config_dir(self.instance))
         except Exception as error:
             return ServerFpsMetrics(False, error=str(error))
+
+    def _query_server_operational_status(self) -> ServerOperationalStatus:
+        try:
+            return query_server_operational_status(paths.config_dir(self.instance))
+        except Exception as error:
+            return ServerOperationalStatus(
+                False,
+                severity="warning",
+                message="Telemetry log unavailable",
+                error=str(error),
+            )
+
+    @staticmethod
+    def _plain_operational_value(status: ServerOperationalStatus) -> str:
+        return _(status.message or "Unknown")
+
+    @staticmethod
+    def _format_operational_status_value(status: ServerOperationalStatus) -> str:
+        value = escape(_(status.message or "Unknown"))
+        if status.severity == "error":
+            return f"[red]{value}[/red]"
+        if status.severity == "warning":
+            return f"[yellow]{value}[/yellow]"
+        if status.severity == "success":
+            return f"[green]{value}[/green]"
+        return value
+
+    def _server_operational_lines(
+        self,
+        status: ServerOperationalStatus,
+    ) -> list[str]:
+        lines = [
+            tr(
+                "Operational status: {value}",
+                value=self._format_operational_status_value(status),
+            )
+        ]
+        for detail in status.details[:2]:
+            lines.append(tr("Latest log: {value}", value=escape(detail)))
+        if status.age_seconds is not None:
+            lines.append(
+                tr(
+                    "Telemetry age: {value}",
+                    value=format_duration(status.age_seconds),
+                )
+            )
+        return lines
 
     def _server_fps_lines(self, fps_metrics: ServerFpsMetrics) -> list[str]:
         if fps_metrics.available:
@@ -641,6 +700,7 @@ class ManageScreen(Screen):
         metrics = query_service_runtime_metrics(service_status)
         host_metrics = self._query_host_metrics()
         fps_metrics = self._query_server_fps_metrics()
+        operational_status = self._query_server_operational_status()
 
         if state.config_exists and state.config_path:
             config_summary, mods_summary = load_status_summaries(state.config_path)
@@ -658,6 +718,9 @@ class ManageScreen(Screen):
                 "Service enabled: {value}",
                 value=self._yes_no(service_status.get("enabled")),
             ),
+            "",
+            _("[bold cyan]Operational Status[/bold cyan]"),
+            *self._server_operational_lines(operational_status),
             "",
             _("[bold cyan]Players[/bold cyan]"),
             tr(
@@ -764,6 +827,7 @@ class ManageScreen(Screen):
         metrics = query_service_runtime_metrics(service_status)
         host_metrics = self._query_host_metrics()
         fps_metrics = self._query_server_fps_metrics()
+        operational_status = self._query_server_operational_status()
         main_pid = metrics.pid
         if state.config_exists and state.config_path:
             config_summary, mods_summary = load_status_summaries(state.config_path)
@@ -790,6 +854,9 @@ class ManageScreen(Screen):
                 value=_("Yes") if service_status.get("enabled") else _("No"),
             ),
             tr("Main PID: {value}", value=main_pid or unknown_text),
+            "",
+            _("[bold cyan]Operational Status[/bold cyan]"),
+            *self._server_operational_lines(operational_status),
             "",
             _("[bold cyan]Timer Status[/bold cyan]"),
             tr("Timer: {value}", value=timer_name),

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -323,3 +323,75 @@ def test_query_server_fps_metrics_ignores_malformed_lines(tmp_path: Path) -> Non
 
     assert result.available is False
     assert result.error == "server FPS telemetry line is not available"
+def test_query_server_operational_status_reports_mod_download_retry(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "config"
+    log_path = _write_console_log(
+        config_dir,
+        "2026-05-18_230000",
+        "\n".join(
+            [
+                "23:00:10.103 NETWORK : Starting dedicated server using command line args.",
+                "23:00:12.182 BACKEND : Addon Download started 6872C012EBB3A7D4",
+                "23:01:54.012 BACKEND (E): Fragmentizer: Download error",
+                "23:01:54.112 BACKEND (E): Fragmentizer: Retrying download",
+            ]
+        ),
+        mtime=1000.0,
+    )
+
+    with patch("armactl.metrics.time.time", return_value=1005.0):
+        result = metrics.query_server_operational_status(config_dir)
+
+    assert result.available is True
+    assert result.state == "downloading_mods"
+    assert result.severity == "warning"
+    assert result.message == "Downloading mods (retrying)"
+    assert result.source == str(log_path)
+    assert "Retrying download" in result.details[0]
+
+
+def test_query_server_operational_status_reports_mission_error(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    _write_console_log(
+        config_dir,
+        "2026-05-18_230000",
+        "\n".join(
+            [
+                "23:00:09.955 BACKEND : Loading dedicated server config.",
+                "23:00:09.955 RESOURCES (E): Failed to open",
+                "23:00:09.955 RESOURCES (E): MissionHeader::ReadMissionHeader "
+                "cannot load the resource 'Missions/TRYZUB_Conflict.conf'!",
+            ]
+        ),
+        mtime=1000.0,
+    )
+
+    with patch("armactl.metrics.time.time", return_value=1005.0):
+        result = metrics.query_server_operational_status(config_dir)
+
+    assert result.available is True
+    assert result.state == "mission_error"
+    assert result.severity == "error"
+    assert result.message == "Mission/config error"
+
+
+def test_query_server_operational_status_reports_ready_from_fps(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "config"
+    _write_console_log(
+        config_dir,
+        "2026-05-18_230000",
+        SAMPLE_FPS_LINE,
+        mtime=1000.0,
+    )
+
+    with patch("armactl.metrics.time.time", return_value=1005.0):
+        result = metrics.query_server_operational_status(config_dir)
+
+    assert result.available is True
+    assert result.state == "ready"
+    assert result.severity == "success"
+    assert result.message == "Ready"

--- a/tests/test_service_integration.py
+++ b/tests/test_service_integration.py
@@ -158,7 +158,7 @@ exec "${SERVER_DIR}/ArmaReforgerServer" \
 
     start_script_text = start_script_path.read_text(encoding="utf-8")
     assert result.success is True
-    assert "Updated generated start script" in result.message
+    assert result.exit_code == 0
     assert "PROFILE_DIR=" not in start_script_text
     assert f'CONFIG_DIR="{config_dir}"' in start_script_text
     assert '-profile "${CONFIG_DIR}"' in start_script_text


### PR DESCRIPTION
## Summary

- What changed?
  - Added server operational status detection from recent `console.log` lines.
  - Added TUI indicators for states like:
    - `Ready`
    - `Starting`
    - `Downloading mods`
    - `Downloading mods (retrying)`
    - `Mission/config error`
    - `Waiting for server telemetry`
    - `Telemetry stale`
  - Added an **Operational Status** block to Manage Server overview/status views.
  - Added operational status to the Manage Server header line, so users do not need to open Live Logs just to understand what the server is doing.
  - Added tests for mod download retry, mission/config error, and ready/FPS states.
  - Made one existing generated-script test language-independent by avoiding assertions against localized user-facing text.

- Why was this needed?
  - `systemd active/running` only means the Arma server process is alive; it does not mean the game server is ready.
  - In real use, the TUI could show `SERVER IS RUNNING` while the server was still downloading mods, retrying failed downloads, or failing to load a mission.
  - Operators had to open Live Logs manually to understand the actual server state.

## Related issue

Closes #

## Validation

- [ ] `./scripts/run-host-tests`
- [x] `python3 -m pytest -q`
- [x] `python3 -m ruff check src tests`
- [x] Relevant manual flow tested
- [x] TUI flow tested, if this PR changes Textual screens or user interaction
- [x] The changed files are relevant to the linked issue
- [x] This PR does not introduce unrelated changes

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [ ] systemd / timer
- [ ] config.json handling
- [ ] Mods / addon cleanup
- [x] TUI / UX / Textual screens
- [ ] Telegram bot
- [ ] Release / versioning
- [ ] docs only

## Automated contribution disclosure

- [x] This PR was written or substantially reviewed by a human maintainer/contributor
- [x] This is not a low-effort automated bounty submission
- [x] If AI or automation was used, the generated changes were manually reviewed

## Notes

- No migration is required.
- No config changes are required.
- Rollback is safe: this only adds best-effort log-derived status display.
- Operator-facing implication:
  - Manage Server now shows a more accurate runtime state than just systemd `running/stopped`.
  - If the server is downloading mods or retrying failed addon downloads, the TUI can show that directly.
  - If the mission/config fails to load, the TUI can surface that as an operational error.
- Manual flow tested:
  - Observed a running server whose latest log showed addon download/retry activity while FPS telemetry was not yet available.
  - Confirmed the need for a TUI-visible operational state instead of requiring Live Logs.
- TUI screens affected:
  - Manage Server overview/status/header.