### PR TITLE
retry SteamCMD server downloads during install

### DIFF
--- a/src/armactl/installer.py
+++ b/src/armactl/installer.py
@@ -11,6 +11,7 @@ import secrets
 import shutil
 import subprocess
 import sys
+import time
 from collections import deque
 from collections.abc import Iterator
 from pathlib import Path
@@ -39,6 +40,31 @@ from armactl.service_manager import (
 
 class InstallError(Exception):
     """Raised when installation fails at any step."""
+
+
+STEAMCMD_MAX_ATTEMPTS = 3
+STEAMCMD_RETRY_DELAYS_SECONDS = (10.0, 30.0)
+STEAMCMD_PERMANENT_ERROR_MARKERS = (
+    "No subscription",
+    "Invalid platform",
+    "Account login denied",
+)
+
+
+def _steamcmd_error_is_permanent(error: InstallError) -> bool:
+    """Return True when retrying the SteamCMD failure is unlikely to help."""
+    message = str(error)
+    return any(marker in message for marker in STEAMCMD_PERMANENT_ERROR_MARKERS)
+
+
+def _steamcmd_retry_delay(
+    attempt: int,
+    retry_delays: tuple[float, ...],
+) -> float:
+    """Return the retry delay after a failed SteamCMD attempt."""
+    if not retry_delays:
+        return 0.0
+    return retry_delays[min(attempt - 1, len(retry_delays) - 1)]
 
 
 def _validated_server_dir(instance: str) -> Path:
@@ -277,13 +303,36 @@ def stream_server_update(
     install_dir: Path,
     *,
     instance: str = paths.DEFAULT_INSTANCE_NAME,
+    max_attempts: int = STEAMCMD_MAX_ATTEMPTS,
+    retry_delays: tuple[float, ...] = STEAMCMD_RETRY_DELAYS_SECONDS,
 ) -> Iterator[str]:
-    """Run SteamCMD app_update validate for a specific install directory."""
+    """Run SteamCMD app_update validate with retries for transient failures."""
     cmd = build_steamcmd_update_command(install_dir, instance=instance)
-    yield from _stream_cmd(
-        cmd,
-        err_msg="Failed to download server via steamcmd",
-    )
+    attempts = max(max_attempts, 1)
+
+    for attempt in range(1, attempts + 1):
+        if attempts > 1:
+            yield f"SteamCMD server download attempt {attempt}/{attempts}..."
+
+        try:
+            yield from _stream_cmd(
+                cmd,
+                err_msg="Failed to download server via steamcmd",
+            )
+            return
+        except InstallError as error:
+            if attempt >= attempts or _steamcmd_error_is_permanent(error):
+                raise
+
+            delay_seconds = _steamcmd_retry_delay(attempt, retry_delays)
+            if delay_seconds > 0:
+                yield (
+                    "SteamCMD download failed; "
+                    f"retrying in {delay_seconds:.0f}s..."
+                )
+                time.sleep(delay_seconds)
+            else:
+                yield "SteamCMD download failed; retrying..."
 
 
 def record_package_manifest(instance: str) -> None:

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -154,6 +154,7 @@ def test_download_server_streams_steamcmd_output_lines() -> None:
         lines = list(installer.download_server("default"))
 
     assert lines == [
+        "SteamCMD server download attempt 1/3...",
         "Connecting anonymously to Steam Public...OK",
         "Success! App '1874900' fully installed.",
     ]

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -173,3 +173,102 @@ def test_installer_refuses_install_dir_inside_git_working_tree(tmp_path: Path) -
 
     with pytest.raises(installer.InstallError, match="Git working tree"):
         installer.build_steamcmd_update_command(install_dir)
+
+
+def test_download_server_retries_transient_steamcmd_failure() -> None:
+    class FakeProc:
+        def __init__(self, lines: list[str], return_code: int) -> None:
+            self.stdout = iter(lines)
+            self._return_code = return_code
+
+        def wait(self) -> int:
+            return self._return_code
+
+    procs = [
+        FakeProc(
+            ["ERROR! Failed to install app '1874900' (Missing configuration)\n"],
+            7,
+        ),
+        FakeProc(["Success! App '1874900' fully installed.\n"], 0),
+    ]
+
+    with (
+        patch("armactl.installer.paths.server_dir", return_value=Path("/tmp/server")),
+        patch(
+            "armactl.installer._resolve_steamcmd_binary",
+            return_value="/usr/games/steamcmd",
+        ),
+        patch("armactl.installer.subprocess.Popen", side_effect=procs) as popen_mock,
+        patch("armactl.installer.time.sleep") as sleep_mock,
+    ):
+        lines = list(installer.download_server("default"))
+
+    assert popen_mock.call_count == 2
+    sleep_mock.assert_called_once_with(10.0)
+    assert "SteamCMD server download attempt 1/3..." in lines
+    assert "SteamCMD download failed; retrying in 10s..." in lines
+    assert "SteamCMD server download attempt 2/3..." in lines
+    assert "Success! App '1874900' fully installed." in lines
+
+
+def test_stream_server_update_raises_after_retry_attempts() -> None:
+    class FakeProc:
+        def __init__(self) -> None:
+            self.stdout = iter(
+                ["ERROR! Failed to install app '1874900' (Missing configuration)\n"]
+            )
+
+        def wait(self) -> int:
+            return 7
+
+    with (
+        patch(
+            "armactl.installer._resolve_steamcmd_binary",
+            return_value="/usr/games/steamcmd",
+        ),
+        patch(
+            "armactl.installer.subprocess.Popen",
+            side_effect=[FakeProc(), FakeProc()],
+        ) as popen_mock,
+        patch("armactl.installer.time.sleep") as sleep_mock,
+    ):
+        with pytest.raises(installer.InstallError) as exc_info:
+            list(
+                installer.stream_server_update(
+                    Path("/tmp/server"),
+                    max_attempts=2,
+                    retry_delays=(0.0,),
+                )
+            )
+
+    assert popen_mock.call_count == 2
+    sleep_mock.assert_not_called()
+    assert "Missing configuration" in str(exc_info.value)
+
+
+def test_download_server_does_not_retry_permanent_steamcmd_error() -> None:
+    class FakeProc:
+        def __init__(self) -> None:
+            self.stdout = iter(
+                ["ERROR! Failed to install app '1874900' (No subscription)\n"]
+            )
+
+        def wait(self) -> int:
+            return 7
+
+    with (
+        patch("armactl.installer.paths.server_dir", return_value=Path("/tmp/server")),
+        patch(
+            "armactl.installer._resolve_steamcmd_binary",
+            return_value="/usr/games/steamcmd",
+        ),
+        patch(
+            "armactl.installer.subprocess.Popen",
+            return_value=FakeProc(),
+        ) as popen_mock,
+    ):
+        with pytest.raises(installer.InstallError) as exc_info:
+            list(installer.download_server("default"))
+
+    popen_mock.assert_called_once()
+    assert "No subscription" in str(exc_info.value)


### PR DESCRIPTION
## Summary

- What changed?
  - Added retry handling around SteamCMD server download/update during install.
  - SteamCMD `app_update 1874900 validate` now retries transient failures instead of failing immediately after the first non-zero exit.
  - Added coverage for:
    - retryable SteamCMD failure followed by success;
    - non-retryable/permanent SteamCMD failure;
    - exhausted retry attempts preserving useful SteamCMD error output.

- Why was this needed?
  - During installation, SteamCMD can fail with transient backend/network errors such as `Missing configuration`.
  - Before this change, `armactl` treated the first SteamCMD failure as fatal and aborted the install.
  - This made clean installs fragile when Steam/CDN/network hiccups occurred, even though a retry could complete successfully.

## Related issue

Closes #

## Validation

- [ ] `./scripts/run-host-tests`
- [ ] `python3 -m pytest -q`
- [ ] `python3 -m ruff check src tests`
- [x] Relevant manual flow tested
- [ ] TUI flow tested, if this PR changes Textual screens or user interaction
- [x] The changed files are relevant to the linked issue
- [x] This PR does not introduce unrelated changes

## Risk areas

- [x] Install / bootstrap
- [ ] Existing server detection
- [ ] systemd / timer
- [ ] config.json handling
- [ ] Mods / addon cleanup
- [ ] TUI / UX / Textual screens
- [ ] Telegram bot
- [ ] Release / versioning
- [ ] docs only

## Automated contribution disclosure

- [x] This PR was written or substantially reviewed by a human maintainer/contributor
- [x] This is not a low-effort automated bounty submission
- [x] If AI or automation was used, the generated changes were manually reviewed

## Notes

- No migration is required.
- No config changes are required.
- Rollback is safe: this only changes SteamCMD install/update retry behavior.
- Operator-facing implication:
  - Transient SteamCMD failures during initial install are retried automatically.
  - Permanent SteamCMD errors should still fail and surface the SteamCMD output.
  - Interrupted/failed installs still keep the existing install marker behavior, so partial installs should not appear as completed installs.
- Manual flow tested:
  - Reproduced install failure context where SteamCMD returned `Failed to install app '1874900' (Missing configuration)`.
  - Applied the patch on a clean branch from current `main`.
  - Confirmed the diff only affects installer retry handling and installer tests.
- TUI screens affected:
  - None.