### PR TITLE
Prepare v0.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Semantic Versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-05-21
+
+### Added
+- Added generated runtime script synchronization for existing installations after template updates.
+- Added `sync-generated` to refresh generated runtime launch files without running full repair.
+- Added TUI operational server status from recent console logs.
+- Added operational states for ready, starting, downloading mods, retrying downloads, mission/config errors, waiting for telemetry, and stale telemetry.
+
+### Changed
+- Manage Server now surfaces the real log-derived operational state in addition to systemd running/stopped status.
+
+### Fixed
+- Fixed stale generated launch scripts after updating armactl templates.
+- Fixed FPS telemetry visibility for existing installations that still used the legacy profile path.
+- Added retry handling for SteamCMD server download/update during install.
+- Made clean installs more resilient to transient SteamCMD backend/network failures such as `Missing configuration`.
+
+### Notes
+- Existing installations should run `./armactl sync-generated` and restart the Arma Reforger service after updating.
+- New installations work out of the box and retry transient SteamCMD install failures automatically.
+
 ## [0.5.1] - 2026-05-15
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "armactl"
-version = "0.5.1"
+version = "0.5.2"
 description = "Installer, manager and TUI for Arma Reforger Dedicated Server on Linux"
 readme = "README.md"
 license = "MIT"

--- a/src/armactl/__init__.py
+++ b/src/armactl/__init__.py
@@ -1,3 +1,3 @@
 """armactl - installer, manager and TUI for Arma Reforger Dedicated Server."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.2"


### PR DESCRIPTION
## Summary

- What changed?
  - Bumped package version to `0.5.2`.
  - Synchronized `src/armactl/__init__.py` version metadata.
  - Added `CHANGELOG.md` notes for v0.5.2.

- Why was this needed?
  - Prepares the v0.5.2 bugfix release after merging generated runtime script sync, TUI operational status, and SteamCMD install retry handling.

## Related issue

Closes #

## Validation

- [ ] `./scripts/run-host-tests`
- [ ] `python3 -m pytest -q`
- [ ] `python3 -m ruff check src tests`
- [ ] Relevant manual flow tested
- [ ] TUI flow tested, if this PR changes Textual screens or user interaction
- [x] The changed files are relevant to the linked issue
- [x] This PR does not introduce unrelated changes

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [ ] systemd / timer
- [ ] config.json handling
- [ ] Mods / addon cleanup
- [ ] TUI / UX / Textual screens
- [ ] Telegram bot
- [x] Release / versioning
- [ ] docs only

## Automated contribution disclosure

- [x] This PR was written or substantially reviewed by a human maintainer/contributor
- [x] This is not a low-effort automated bounty submission
- [x] If AI or automation was used, the generated changes were manually reviewed

## Notes

- No migration is required.
- Rollback is safe: revert the version/changelog bump.
- Release includes:
  - generated runtime script sync for existing installations;
  - TUI operational server status;
  - SteamCMD install retry handling for transient download/update failures.