### PR TITLE
docs: standardize release process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+﻿# AI contributor instructions for armactl
+
+When preparing releases, do not invent a new release format.
+
+Use these files as the source of truth:
+
+- `docs/release-process.md`
+- `docs/release-notes-template.md`
+- `CHANGELOG.md`
+
+Release PRs should normally update only:
+
+- `pyproject.toml`
+- `src/armactl/__init__.py`
+- `CHANGELOG.md`
+
+Keep release notes consistent with previous releases:
+
+- `Added`
+- `Changed`
+- `Fixed`
+- `Validation`
+- `Operational notes`
+
+Use concise, operator-focused bullets.
+Do not add unrelated code changes to release PRs.

--- a/docs/release-notes-template.md
+++ b/docs/release-notes-template.md
@@ -1,0 +1,22 @@
+﻿## armactl vX.Y.Z
+
+### Added
+- Added ...
+
+### Changed
+- Changed ...
+
+### Fixed
+- Fixed ...
+
+### Validation
+- `git diff --check`
+- `python3 -m ruff check src tests`
+- `python3 -m pytest -q`
+- Manual smoke test: ...
+
+### Operational notes
+- Existing installations should ...
+- New installations ...
+
+Full Changelog: vPREVIOUS...vX.Y.Z

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,51 +1,87 @@
-# Release Process
+﻿# Release process
 
-## Goal
+This document is the source of truth for preparing armactl releases.
 
-Ship a GitHub Release that matches the repo-local operational model of
-`armactl`, not just a library-style Python package.
+## Versioning
 
-## Before tagging
+Use semantic versioning-style increments:
 
-- Update [CHANGELOG.md](../CHANGELOG.md)
-- Confirm README and docs are current
-- Run:
+- Patch release: bug fixes, operational fixes, resilience improvements, small TUI/UX improvements.
+- Minor release: new user-facing features or larger workflow changes.
+- Major release: breaking changes.
 
-  ```bash
-  ./scripts/run-host-tests
-  ```
+For each release, update all version metadata:
 
-- Confirm manual smoke coverage on:
-  - fresh install
-  - existing server
-  - reboot flow
-- Confirm Server FPS telemetry on a live server:
-  - generated process args include `-logStats 10000`
-  - runtime `console.log` contains `FPS:` / `frame time`
-  - `./armactl status` shows `Server FPS`, `Frame time`, and telemetry age
-  - TUI and Telegram metrics do not crash when telemetry is missing or stale
+- `pyproject.toml`
+- `src/armactl/__init__.py`
+- `CHANGELOG.md`
+
+The package version and `__version__` must match the Git tag.
+
+## Changelog style
+
+`CHANGELOG.md` follows a Keep a Changelog-style structure.
+
+Use this section order when applicable:
+
+1. `Added`
+2. `Changed`
+3. `Fixed`
+4. `Validation`
+5. `Operational notes`
+
+Keep bullet points short and operator-focused.
+
+Prefer this wording style:
+
+- `Added ...`
+- `Changed ...`
+- `Fixed ...`
+- `Retried ...`
+- `Preserved ...`
+
+Avoid marketing-style wording. Release notes should describe what changed and what operators need to do.
+
+## Release PR checklist
+
+A release PR should usually include only:
+
+- `pyproject.toml`
+- `src/armactl/__init__.py`
+- `CHANGELOG.md`
+
+PR title format:
+
+    Prepare vX.Y.Z release
+
+Commit message format:
+
+    Prepare vX.Y.Z release
+
+## Validation before tagging
+
+Before creating the Git tag, verify CI is green.
+
+Preferred local checks:
+
+    ./scripts/run-host-tests
+    python3 -m pytest -q
+    python3 -m ruff check src tests
+    git diff --check
+
+If local checks cannot be run, the release PR must pass GitHub Actions before merge.
 
 ## Tagging
 
-Use semantic version tags:
+After the release PR is merged:
 
-```bash
-git tag vX.Y.Z
-git push origin vX.Y.Z
-```
+    git switch main
+    git pull --ff-only
+    git tag -a vX.Y.Z -m "vX.Y.Z"
+    git push origin vX.Y.Z
 
-## Release workflow
+## GitHub Release notes
 
-The GitHub release workflow should:
+Use `docs/release-notes-template.md`.
 
-- build Python artifacts
-- create a source archive suitable for repo-local usage
-- attach artifacts to the GitHub Release page
-
-## After the release is published
-
-- Verify installation from the release archive
-- Verify `./armactl` on another machine
-- Check release notes and attached artifacts
-- Verify an existing installation can regenerate the start script and show
-  Server FPS after restarting `armareforger.service`
+The GitHub Release body should match the changelog style and section order.


### PR DESCRIPTION
## Summary

- What changed?
  - Added release process documentation.
  - Added a reusable GitHub Release notes template.
  - Added `AGENTS.md` instructions so future AI/code-agent sessions use the same release format.

- Why was this needed?
  - Release notes and changelog entries should stay consistent across versions.
  - Future release preparation should not depend on chat memory or ad-hoc formatting.

## Related issue

Closes #

## Validation

- [ ] `./scripts/run-host-tests`
- [ ] `python3 -m pytest -q`
- [ ] `python3 -m ruff check src tests`
- [x] Relevant manual flow tested
- [ ] TUI flow tested, if this PR changes Textual screens or user interaction
- [x] The changed files are relevant to the linked issue
- [x] This PR does not introduce unrelated changes

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [ ] systemd / timer
- [ ] config.json handling
- [ ] Mods / addon cleanup
- [ ] TUI / UX / Textual screens
- [ ] Telegram bot
- [x] Release / versioning
- [x] docs only

## Automated contribution disclosure

- [x] This PR was written or substantially reviewed by a human maintainer/contributor
- [x] This is not a low-effort automated bounty submission
- [x] If AI or automation was used, the generated changes were manually reviewed

## Notes

- No migration is required.
- No runtime behavior changes.
- This only documents the release process and release-note format.