### PR TITLE
fix RCON header-only player roster handling

### DIFF
--- a/src/armactl/rcon.py
+++ b/src/armactl/rcon.py
@@ -307,9 +307,38 @@ def _parse_player_lines(response: str) -> list[PlayerEntry]:
     return entries
 
 
+def _is_empty_player_roster_response(response: str) -> bool:
+    """Return True when RCON returned only login/command noise and roster headers."""
+    meaningful_lines: list[str] = []
+
+    for raw_line in response.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        lowered = line.lower()
+        if lowered.startswith(RCON_NOISE_PREFIXES):
+            continue
+
+        if lowered in {"players on server:", "players on server"}:
+            continue
+
+        if lowered.startswith("players on server:") and "[player" in lowered:
+            continue
+
+        if lowered.startswith("players") and ":" in line:
+            continue
+
+        meaningful_lines.append(line)
+
+    return not meaningful_lines
+
+
 def _query_player_entries(session: _RconSession) -> list[PlayerEntry]:
     """Try the most likely roster commands and return the first non-empty parse."""
     last_error: str = ""
+    saw_empty_roster = False
+
     for command in ("#players", "players"):
         try:
             response = session.send_command(command)
@@ -320,9 +349,15 @@ def _query_player_entries(session: _RconSession) -> list[PlayerEntry]:
         entries = _parse_player_lines(response)
         if entries:
             return entries
+
         if response:
+            if _is_empty_player_roster_response(response):
+                saw_empty_roster = True
+                continue
             last_error = response
 
+    if saw_empty_roster:
+        return []
     if last_error:
         raise RconError(last_error)
     return []

--- a/tests/test_rcon.py
+++ b/tests/test_rcon.py
@@ -305,3 +305,24 @@ def test_query_player_roster_allows_explicit_timeout_override() -> None:
         rcon.query_player_roster("default", timeout=0.25)
 
     assert captured["timeout"] == 0.25
+
+
+def test_query_player_entries_treats_header_only_roster_as_empty() -> None:
+    class FakeSession:
+        def __init__(self) -> None:
+            self.commands: list[str] = []
+
+        def send_command(self, command: str) -> str:
+            self.commands.append(command)
+            return """
+Logged In! Client ID: #0
+Processing Command: #players
+Players on server: [Player#] ; [Player UID] ; [Player Name]
+""".strip()
+
+    session = FakeSession()
+
+    entries = rcon._query_player_entries(session)
+
+    assert entries == []
+    assert session.commands == ["#players", "players"]


### PR DESCRIPTION
## Summary

- What changed?
  - Treat RCON header-only player roster responses as a valid empty roster.
  - Avoid reporting successful RCON login/command responses as connection/password failures when no player rows are returned.
  - Added regression coverage for Arma Reforger `#players` output that contains only login/command noise and the roster header.

- Why was this needed?
  - Telegram and TUI could show the player list as unavailable even though RCON login and `#players` command execution succeeded.
  - The server can return only `Players on server: [Player#] ; [Player UID] ; [Player Name]` without player rows, especially when A2S reports a count but RCON does not yet expose roster entries.

## Validation

- [ ] `./scripts/run-host-tests`
- [ ] `python3 -m pytest -q`
- [ ] `python3 -m ruff check src tests`
- [x] Relevant manual flow tested
- [x] The changed files are relevant to the linked issue
- [x] This PR does not introduce unrelated changes

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [ ] systemd / timer
- [ ] config.json handling
- [ ] Mods / addon cleanup
- [ ] TUI / UX / Textual screens
- [x] Telegram bot
- [ ] Release / versioning
- [ ] docs only

## Notes

- No migration is required.
- No config changes are required.
- Operator-facing implication: header-only RCON roster responses should now appear as an empty player list instead of an RCON availability/password error.