### PR TITLE
fix empty RCON roster display

### DIFF
--- a/src/armactl/locales/uk.json
+++ b/src/armactl/locales/uk.json
@@ -228,6 +228,7 @@
     "[bold cyan]Players[/bold cyan]": "[bold cyan]Гравці[/bold cyan]",
     "Player roster unavailable: {value}": "Список гравців недоступний: {value}",
     "RCON player roster is not configured.": "Список гравців через RCON не налаштовано.",
+    "RCON roster returned no player names yet.": "RCON ще не повернув імена гравців.",
     "Check local RCON address, port, and password.": "Перевірте локальні RCON address, port і password.",
     "No players online.": "Гравців онлайн немає.",
     "- {name} (#{player_id})": "- {name} (#{player_id})",

--- a/src/armactl/telegram_bot.py
+++ b/src/armactl/telegram_bot.py
@@ -489,6 +489,15 @@ def render_bot_players_text(snapshot: BotStatusSnapshot, lang: str) -> str:
         if snapshot.player_lines:
             for index, player_line in enumerate(snapshot.player_lines, start=1):
                 lines.append(f"{index}. {player_line}")
+        elif snapshot.roster_available:
+            lines.append(
+                _bullet_line(
+                    translate_for_lang(
+                        lang,
+                        "RCON roster returned no player names yet.",
+                    )
+                )
+            )
         elif not snapshot.roster_configured:
             lines.append(
                 _bullet_line(

--- a/src/armactl/tui/screens.py
+++ b/src/armactl/tui/screens.py
@@ -1051,6 +1051,8 @@ class ManageScreen(Screen):
                         )
                     else:
                         lines.append(tr("- {name}", name=entry.name))
+            elif roster.available:
+                lines.append(_("RCON roster returned no player names yet."))
             elif roster.configured:
                 lines.append(
                     tr(

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -745,3 +745,30 @@ def test_build_application_configures_telegram_request_timeouts():
     assert fake_application.polling_kwargs["drop_pending_updates"] is True
     assert fake_application.handlers
     assert fake_application.error_handlers == [bot.error_handler]
+
+
+def test_render_bot_players_text_handles_available_empty_roster() -> None:
+    snapshot = telegram_bot.BotStatusSnapshot(
+        instance="default",
+        server_running=True,
+        service_name="armareforger.service",
+        service_active_state="active",
+        service_enabled=True,
+        timer_name="armareforger-restart.timer",
+        schedule="08:00, 20:00",
+        next_run="2026-03-29 08:00:00 UTC",
+        player_count=1,
+        max_players=128,
+        player_lines=[],
+        roster_available=True,
+        roster_configured=True,
+        roster_error="",
+    )
+
+    text = telegram_bot.render_bot_players_text(snapshot, "en")
+
+    assert "Players: default" in text
+    assert "Count: 1/128" in text
+    assert "RCON roster returned no player names yet." in text
+    assert "Player roster unavailable" not in text
+    assert "Check local RCON address, port, and password." not in text


### PR DESCRIPTION
## Summary

- What changed?
  - Updated Telegram Players rendering to treat available-but-empty RCON roster responses as a valid state.
  - Updated TUI player roster rendering with the same behavior.
  - Added Ukrainian translation for the new empty-roster message.
  - Added Telegram regression coverage for available empty RCON roster responses.

- Why was this needed?
  - PR #67 fixed the RCON parser so header-only roster responses no longer become RCON errors.
  - The Telegram/TUI rendering layer still treated `roster_available=True` with no player names as `Player roster unavailable: Unknown`.
  - This caused misleading guidance to check RCON address, port, and password even when RCON was working.

## Validation

- [ ] `./scripts/run-host-tests`
- [ ] `python3 -m pytest -q`
- [ ] `python3 -m ruff check src tests`
- [x] Relevant manual flow tested
- [x] The changed files are relevant to the linked issue
- [x] This PR does not introduce unrelated changes

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [ ] systemd / timer
- [ ] config.json handling
- [ ] Mods / addon cleanup
- [x] TUI / UX / Textual screens
- [x] Telegram bot
- [ ] Release / versioning
- [ ] docs only

## Notes

- No migration is required.
- No config changes are required.
- Operator-facing implication:
  - If A2S reports players but RCON returns only a header/no names yet, Telegram and TUI now show that RCON has not returned player names yet instead of reporting an RCON failure.