### PR TITLE
fix player roster source of truth

### DIFF
--- a/src/armactl/locales/uk.json
+++ b/src/armactl/locales/uk.json
@@ -219,6 +219,7 @@
     "Server metrics unavailable: {value}": "Метрики сервера недоступні: {value}",
     "Host metrics unavailable: {value}": "Метрики хоста недоступні: {value}",
     "[bold yellow]Warnings[/bold yellow]": "[bold yellow]Попередження[/bold yellow]",
+    "Player count source warning: {value}": "Попередження джерела кількості гравців: {value}",
     "Installed mods: {count}": "Встановлено модів: {count}",
     "No mods configured.": "Моди не налаштовано.",
     "Mods summary unavailable.": "Підсумок модів недоступний.",
@@ -531,3 +532,4 @@
     "Telemetry stale": "Телеметрія застаріла"
   }
 }
+

--- a/src/armactl/player_view.py
+++ b/src/armactl/player_view.py
@@ -1,0 +1,92 @@
+"""Unified player status view shared by Telegram and TUI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from armactl.a2s import query_player_status
+from armactl.rcon import PlayerEntry, query_player_roster
+from armactl.state import ServerState
+
+
+@dataclass
+class PlayerView:
+    """Resolved player state from A2S count plus optional RCON roster details."""
+
+    available: bool
+    current: int | None
+    max_players: int | None
+    entries: tuple[PlayerEntry, ...] = ()
+    count_source: str = "a2s"
+    a2s_available: bool = False
+    a2s_count: int | None = None
+    a2s_error: str = ""
+    roster_available: bool = False
+    roster_configured: bool = False
+    roster_error: str = ""
+    warning: str = ""
+
+    @property
+    def player_lines(self) -> list[str]:
+        """Return player names for simple renderers."""
+        return [entry.name for entry in self.entries]
+
+
+def query_player_view(
+    instance: str,
+    *,
+    timeout: float = 1.5,
+    roster_timeout: float = 1.5,
+    state: ServerState | None = None,
+    include_roster: bool = True,
+) -> PlayerView:
+    """Return one player view to avoid Telegram/TUI mixing inconsistent sources.
+
+    A2S is still used for maxPlayers and as a fallback count. When local RCON is
+    available, the RCON roster is the source of truth for the current player
+    count, because it contains concrete player rows and avoids stale A2S ghosts.
+    """
+    player_status = query_player_status(instance, timeout=timeout, state=state)
+    current = player_status.player_count
+    max_players = player_status.max_players
+    entries: tuple[PlayerEntry, ...] = ()
+    count_source = "a2s"
+    roster_available = False
+    roster_configured = False
+    roster_error = ""
+    warning = ""
+
+    resolved_state = state
+    server_running = True if resolved_state is None else resolved_state.server_running
+
+    if include_roster and server_running:
+        roster = query_player_roster(instance, timeout=roster_timeout)
+        roster_available = roster.available
+        roster_configured = roster.configured
+        roster_error = roster.error
+
+        if roster.available:
+            entries = tuple(roster.entries)
+            rcon_count = len(entries)
+            if current is not None and current != rcon_count:
+                warning = (
+                    f"A2S reports {current} player(s), "
+                    f"but RCON roster has {rcon_count}."
+                )
+            current = rcon_count
+            count_source = "rcon"
+
+    return PlayerView(
+        available=player_status.available or roster_available,
+        current=current,
+        max_players=max_players,
+        entries=entries,
+        count_source=count_source,
+        a2s_available=player_status.available,
+        a2s_count=player_status.player_count,
+        a2s_error=player_status.error,
+        roster_available=roster_available,
+        roster_configured=roster_configured,
+        roster_error=roster_error,
+        warning=warning,
+    )

--- a/src/armactl/rcon.py
+++ b/src/armactl/rcon.py
@@ -28,6 +28,7 @@ RCON_ROSTER_TIMEOUT_SECONDS = 1.5
 
 PLAYER_SLOT_SUFFIX_RE = re.compile(r"\s*\(#(?P<player_id>\d+)\)\s*$")
 GUID_LIKE_RE = re.compile(r"^[0-9a-fA-F-]{8,}$")
+HASH_PLAYER_PREFIX_RE = re.compile(r"^#(?P<player_id>\d+)\s+(?P<name>.+?)\s*$")
 
 
 class RconError(Exception):
@@ -129,6 +130,7 @@ def _parse_reforger_player_line(line: str) -> PlayerEntry | None:
 
     guid_index: int | None = None
     guid: str | None = None
+    player_id: str | None = None
     for index, part in enumerate(parts):
         candidate = part.lstrip("#").strip()
         if GUID_LIKE_RE.fullmatch(candidate):
@@ -139,12 +141,17 @@ def _parse_reforger_player_line(line: str) -> PlayerEntry | None:
     if guid_index is None or guid is None:
         return None
 
+    for part in parts[:guid_index]:
+        candidate = part.lstrip("#").strip()
+        if candidate.isdigit():
+            player_id = candidate
+            break
+
     trailing_parts = [part.strip() for part in parts[guid_index + 1 :] if part.strip()]
     if not trailing_parts:
         return None
 
     tail = trailing_parts[-1]
-    player_id = None
     slot_match = PLAYER_SLOT_SUFFIX_RE.search(tail)
     if slot_match:
         player_id = slot_match.group("player_id")
@@ -283,12 +290,23 @@ def _parse_player_lines(response: str) -> list[PlayerEntry]:
         if lowered.startswith(RCON_NOISE_PREFIXES):
             continue
 
-        if line.startswith("#"):
-            continue
-
         reforger_entry = _parse_reforger_player_line(line)
         if reforger_entry is not None:
             entries.append(reforger_entry)
+            continue
+
+        hash_match = HASH_PLAYER_PREFIX_RE.match(line)
+        if hash_match:
+            entries.append(
+                PlayerEntry(
+                    name=hash_match.group("name").strip(),
+                    player_id=hash_match.group("player_id"),
+                    raw=line,
+                )
+            )
+            continue
+
+        if line.startswith("#"):
             continue
 
         parts = line.split(maxsplit=1)
@@ -404,3 +422,5 @@ def query_player_roster(
     finally:
         session.logout()
         session.close()
+
+

--- a/src/armactl/telegram_bot.py
+++ b/src/armactl/telegram_bot.py
@@ -14,11 +14,10 @@ from typing import Any
 import armactl.metrics as metrics
 import armactl.status_summary as status_summary
 from armactl import paths
-from armactl.a2s import query_player_status
 from armactl.bot_config import BotConfigError, load_bot_config
 from armactl.discovery import discover
 from armactl.i18n import tr_for_lang, translate_for_lang, using_lang
-from armactl.rcon import query_player_roster
+from armactl.player_view import query_player_view
 from armactl.redaction import redact_sensitive_text
 from armactl.service_manager import (
     disable_service,
@@ -630,7 +629,12 @@ def _build_status_snapshot(
     state = discover(instance, save=False)
     service_status = get_service_status(service_unit_name(instance))
     timer_status = get_timer_status(timer_unit_name(instance))
-    player_status = query_player_status(instance, timeout=player_status_timeout, state=state)
+    player_view = query_player_view(
+        instance,
+        timeout=player_status_timeout,
+        state=state,
+        include_roster=include_roster,
+    )
     runtime_metrics = (
         metrics.query_service_runtime_metrics(service_status)
         if include_runtime_metrics
@@ -644,16 +648,7 @@ def _build_status_snapshot(
     else:
         config_summary = status_summary.ConfigSummary(False)
         mods_summary = status_summary.ModsSummary(False)
-    roster_lines: list[str] = []
-    roster_available = False
-    roster_configured = False
-    roster_error = ""
-    if include_roster and player_status.player_count and player_status.player_count > 0:
-        roster = query_player_roster(instance)
-        roster_available = roster.available
-        roster_configured = roster.configured
-        roster_error = roster.error
-        roster_lines = [entry.name for entry in roster.entries]
+    roster_lines = player_view.player_lines
     return BotStatusSnapshot(
         instance=instance,
         server_running=state.server_running,
@@ -663,8 +658,8 @@ def _build_status_snapshot(
         timer_name=timer_unit_name(instance),
         schedule=timer_status.get("schedule", ""),
         next_run=timer_status.get("next_run", ""),
-        player_count=player_status.player_count,
-        max_players=player_status.max_players,
+        player_count=player_view.current,
+        max_players=player_view.max_players,
         main_pid=main_pid,
         cpu_percent=runtime_metrics.cpu_percent,
         memory_rss_bytes=runtime_metrics.memory_rss_bytes,
@@ -681,9 +676,9 @@ def _build_status_snapshot(
             else metrics.ServerFpsMetrics(False)
         ),
         player_lines=roster_lines,
-        roster_available=roster_available,
-        roster_configured=roster_configured,
-        roster_error=roster_error,
+        roster_available=player_view.roster_available,
+        roster_configured=player_view.roster_configured,
+        roster_error=player_view.roster_error,
     )
 
 
@@ -1448,3 +1443,4 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+

--- a/src/armactl/tui/screens.py
+++ b/src/armactl/tui/screens.py
@@ -27,7 +27,6 @@ from textual.widgets import (
 )
 
 from armactl import paths, ports
-from armactl.a2s import query_player_status
 from armactl.addon_cleanup import cleanup_unconfigured_addons
 from armactl.bot_config import (
     BotConfig,
@@ -73,7 +72,7 @@ from armactl.mods_manager import (
     import_mods_detailed,
     preview_import_mods,
 )
-from armactl.rcon import query_player_roster
+from armactl.player_view import PlayerView, query_player_view
 from armactl.redaction import redact_sensitive_text
 from armactl.repair import run_repair
 from armactl.service_manager import (
@@ -591,6 +590,21 @@ class ManageScreen(Screen):
             return _("Unknown")
         return player_text
 
+    def _player_entry_lines(self, player_view: PlayerView) -> list[str]:
+        lines: list[str] = []
+        for entry in player_view.entries:
+            if entry.player_id:
+                lines.append(
+                    tr(
+                        "- {name} (#{player_id})",
+                        name=entry.name,
+                        player_id=entry.player_id,
+                    )
+                )
+            else:
+                lines.append(tr("- {name}", name=entry.name))
+        return lines
+
     def _format_bytes_pair(
         self,
         used: int | None,
@@ -696,7 +710,7 @@ class ManageScreen(Screen):
     def _build_overview_text(self) -> str:
         state = discover(self.instance, save=False)
         service_status = get_service_status(self._service_name())
-        player_status = query_player_status(self.instance, state=state)
+        player_view = query_player_view(self.instance, state=state, include_roster=True)
         metrics = query_service_runtime_metrics(service_status)
         host_metrics = self._query_host_metrics()
         fps_metrics = self._query_server_fps_metrics()
@@ -726,8 +740,8 @@ class ManageScreen(Screen):
             tr(
                 "Players: {value}",
                 value=self._format_players(
-                    player_status.player_count,
-                    player_status.max_players,
+                    player_view.current,
+                    player_view.max_players,
                 ),
             ),
             "",
@@ -790,8 +804,10 @@ class ManageScreen(Screen):
         ]
 
         warnings: list[str] = []
-        if player_status.player_count is None:
+        if player_view.current is None:
             warnings.append(_("Players: unavailable"))
+        if player_view.warning:
+            warnings.append(player_view.warning)
         if not metrics.available:
             warnings.append(
                 tr(
@@ -823,7 +839,7 @@ class ManageScreen(Screen):
         timer_name = timer_unit_name(self.instance)
         service_status = get_service_status(service_name)
         timer_status = get_timer_status(timer_name)
-        player_status = query_player_status(self.instance, state=state)
+        player_view = query_player_view(self.instance, state=state, include_roster=True)
         metrics = query_service_runtime_metrics(service_status)
         host_metrics = self._query_host_metrics()
         fps_metrics = self._query_server_fps_metrics()
@@ -1019,51 +1035,42 @@ class ManageScreen(Screen):
             ]
         )
 
-        if player_status.player_count is None:
+        if player_view.current is None:
             lines.append(_("Players: unavailable"))
-        elif player_status.max_players is None:
+        elif player_view.max_players is None:
             lines.append(
                 tr(
                     "Players: {current}",
-                    current=player_status.player_count,
+                    current=player_view.current,
                 )
             )
         else:
             lines.append(
                 tr(
                     "Players: {current}/{max}",
-                    current=player_status.player_count,
-                    max=player_status.max_players,
+                    current=player_view.current,
+                    max=player_view.max_players,
                 )
             )
 
-        if player_status.player_count and player_status.player_count > 0:
-            roster = query_player_roster(self.instance)
-            if roster.available and roster.entries:
-                for entry in roster.entries:
-                    if entry.player_id:
-                        lines.append(
-                            tr(
-                                "- {name} (#{player_id})",
-                                name=entry.name,
-                                player_id=entry.player_id,
-                            )
-                        )
-                    else:
-                        lines.append(tr("- {name}", name=entry.name))
-            elif roster.available:
-                lines.append(_("RCON roster returned no player names yet."))
-            elif roster.configured:
-                lines.append(
-                    tr(
-                        "Player roster unavailable: {value}",
-                        value=roster.error or _("Unknown"),
-                    )
-                )
-            else:
-                lines.append(_("RCON player roster is not configured."))
-        elif player_status.player_count == 0:
+        if player_view.entries:
+            lines.extend(self._player_entry_lines(player_view))
+        elif player_view.current == 0:
             lines.append(_("No players online."))
+        elif player_view.roster_available:
+            lines.append(_("RCON roster returned no player names yet."))
+        elif player_view.roster_configured:
+            lines.append(
+                tr(
+                    "Player roster unavailable: {value}",
+                    value=player_view.roster_error or _("Unknown"),
+                )
+            )
+        else:
+            lines.append(_("RCON player roster is not configured."))
+
+        if player_view.warning:
+            lines.append(tr("Player count source warning: {value}", value=player_view.warning))
 
         return "\n".join(lines)
 
@@ -2956,3 +2963,4 @@ class ModManagerScreen(Screen):
             )
             if count > 0:
                 await self.action_refresh_mods()
+

--- a/tests/test_player_view.py
+++ b/tests/test_player_view.py
@@ -1,0 +1,108 @@
+"""Tests for unified player view source selection."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from armactl.a2s import PlayerStatus
+from armactl.player_view import query_player_view
+from armactl.rcon import PlayerEntry, PlayerRoster
+from armactl.state import PortInfo, ServerState
+
+
+def _running_state() -> ServerState:
+    return ServerState(server_running=True, ports=PortInfo(a2s=17777, rcon=19999))
+
+
+def test_player_view_prefers_available_rcon_roster_count_over_a2s_ghost_count() -> None:
+    with (
+        patch(
+            "armactl.player_view.query_player_status",
+            return_value=PlayerStatus(
+                available=True,
+                host="127.0.0.1",
+                port=17777,
+                player_count=2,
+                max_players=128,
+            ),
+        ),
+        patch(
+            "armactl.player_view.query_player_roster",
+            return_value=PlayerRoster(
+                available=True,
+                configured=True,
+                host="127.0.0.1",
+                port=19999,
+                entries=[PlayerEntry(name="deus", player_id="1")],
+            ),
+        ),
+    ):
+        view = query_player_view("default", state=_running_state(), include_roster=True)
+
+    assert view.current == 1
+    assert view.max_players == 128
+    assert view.count_source == "rcon"
+    assert view.player_lines == ["deus"]
+    assert view.a2s_count == 2
+    assert view.warning == "A2S reports 2 player(s), but RCON roster has 1."
+
+
+def test_player_view_uses_empty_available_rcon_roster_as_zero_players() -> None:
+    with (
+        patch(
+            "armactl.player_view.query_player_status",
+            return_value=PlayerStatus(
+                available=True,
+                host="127.0.0.1",
+                port=17777,
+                player_count=2,
+                max_players=128,
+            ),
+        ),
+        patch(
+            "armactl.player_view.query_player_roster",
+            return_value=PlayerRoster(
+                available=True,
+                configured=True,
+                host="127.0.0.1",
+                port=19999,
+                entries=[],
+            ),
+        ),
+    ):
+        view = query_player_view("default", state=_running_state(), include_roster=True)
+
+    assert view.current == 0
+    assert view.count_source == "rcon"
+    assert view.player_lines == []
+    assert view.warning == "A2S reports 2 player(s), but RCON roster has 0."
+
+
+def test_player_view_falls_back_to_a2s_when_rcon_is_unavailable() -> None:
+    with (
+        patch(
+            "armactl.player_view.query_player_status",
+            return_value=PlayerStatus(
+                available=True,
+                host="127.0.0.1",
+                port=17777,
+                player_count=2,
+                max_players=128,
+            ),
+        ),
+        patch(
+            "armactl.player_view.query_player_roster",
+            return_value=PlayerRoster(
+                available=False,
+                configured=True,
+                host="127.0.0.1",
+                port=19999,
+                error="RCON command timed out.",
+            ),
+        ),
+    ):
+        view = query_player_view("default", state=_running_state(), include_roster=True)
+
+    assert view.current == 2
+    assert view.count_source == "a2s"
+    assert view.roster_error == "RCON command timed out."

--- a/tests/test_rcon.py
+++ b/tests/test_rcon.py
@@ -68,6 +68,21 @@ Processing Command: #players
     assert entries[0].guid == "0109fcf5-a861-4002-881e-8a497c59797c"
 
 
+def test_parse_player_lines_supports_reforger_hash_prefixed_player_number():
+    response = """
+Logged In! Client ID: #0
+Processing Command: #players
+Players on server: [Player#] ; [Player UID] ; [Player Name]
+#1 ; 0109fcf5-a861-4002-881e-8a497c59797c ; MisanTropiC#DivisioN
+""".strip()
+
+    entries = rcon._parse_player_lines(response)
+
+    assert len(entries) == 1
+    assert entries[0].name == "MisanTropiC#DivisioN"
+    assert entries[0].player_id == "1"
+    assert entries[0].guid == "0109fcf5-a861-4002-881e-8a497c59797c"
+
 def test_parse_player_lines_supports_legacy_numeric_format():
     response = "17 Denis"
 
@@ -326,3 +341,4 @@ Players on server: [Player#] ; [Player UID] ; [Player Name]
 
     assert entries == []
     assert session.commands == ["#players", "players"]
+


### PR DESCRIPTION
## Summary

- What changed?
  - Added a shared `player_view` backend that resolves player count and roster state in one place.
  - Updated Telegram and TUI player displays to use the same resolved player view instead of duplicating A2S/RCON logic.
  - Prefer RCON roster as the source of truth for current player count when RCON returns actual player entries.
  - Keep A2S as fallback for player count and as the source for `maxPlayers`.
  - Fixed RCON parsing for Reforger roster rows like `#1 ; UID ; PlayerName`.
  - Added regression tests for hash-prefixed RCON player rows and A2S/RCON count mismatch.

- Why was this needed?
  - A2S can report phantom/stale player counts while RCON returns the actual player roster.
  - Before this change Telegram/TUI could show a count like `2/128` while listing only one real player.
  - Telegram and TUI also had separate player-count/roster handling, which could drift and produce inconsistent output.
  - This change gives both UIs one shared source of truth for player display state.

## Related issue

Closes #

## Validation

- [ ] `./scripts/run-host-tests`
- [ ] `python3 -m pytest -q`
- [ ] `python3 -m ruff check src tests`
- [ ] Relevant manual flow tested
- [ ] TUI flow tested, if this PR changes Textual screens or user interaction
- [x] The changed files are relevant to the linked issue
- [x] This PR does not introduce unrelated changes

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [ ] systemd / timer
- [ ] config.json handling
- [ ] Mods / addon cleanup
- [x] TUI / UX / Textual screens
- [x] Telegram bot
- [ ] Release / versioning
- [ ] docs only

## Automated contribution disclosure

- [x] This PR was written or substantially reviewed by a human maintainer/contributor
- [x] This is not a low-effort automated bounty submission
- [x] If AI or automation was used, the generated changes were manually reviewed

## Notes

- No migration is required.
- No config changes are required.
- Rollback is safe: reverting this PR restores the previous A2S-first player count behavior.
- Operator-facing implication:
  - When RCON returns actual player entries, Telegram and TUI now display the current player count based on the RCON roster.
  - A2S remains the fallback when RCON is unavailable or no roster entries are returned.
  - `maxPlayers` still comes from A2S/config.
- TUI manual flow to test:
  - Open `Manage Existing Server`.
  - Check the overview/status player count.
  - Open the detailed status/player section.
  - Confirm the count matches the listed RCON player names.
- Telegram manual flow to test:
  - Open the bot menu.
  - Press `Players`.
  - Confirm the count matches the listed RCON player names.