### PR TITLE
fix telegram status player source

### DIFF
--- a/src/armactl/telegram_bot.py
+++ b/src/armactl/telegram_bot.py
@@ -926,7 +926,7 @@ class ArmaCtlTelegramBot:
                 include_summaries=True,
                 player_status_timeout=TELEGRAM_PLAYER_STATUS_TIMEOUT_SECONDS,
             )
-        elif view == "players":
+        elif view in {"players", "status"}:
             snapshot = _build_status_snapshot(
                 self.instance,
                 include_roster=True,
@@ -1443,4 +1443,5 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+
 

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -407,6 +407,7 @@ def test_bot_snapshot_cache_reuses_view_data_until_refresh():
     telegram_timeout = telegram_bot.TELEGRAM_PLAYER_STATUS_TIMEOUT_SECONDS
     assert build.call_args_list[0] == mock.call(
         "default",
+        include_roster=True,
         player_status_timeout=telegram_timeout,
     )
     assert build.call_args_list[1] == mock.call(
@@ -427,6 +428,7 @@ def test_bot_snapshot_cache_reuses_view_data_until_refresh():
     )
     assert build.call_args_list[4] == mock.call(
         "default",
+        include_roster=True,
         player_status_timeout=telegram_timeout,
     )
 
@@ -772,3 +774,4 @@ def test_render_bot_players_text_handles_available_empty_roster() -> None:
     assert "RCON roster returned no player names yet." in text
     assert "Player roster unavailable" not in text
     assert "Check local RCON address, port, and password." not in text
+


### PR DESCRIPTION
## Summary

- What changed?
  - Updated Telegram Status snapshots to include the unified RCON-aware player view.
  - Telegram `Status` now uses the same player count source as Telegram `Players`.
  - Updated the Telegram snapshot cache regression test expectations.

- Why was this needed?
  - Telegram `Players` already used the unified RCON-aware player view, but Telegram `Status` still used the A2S-only count path.
  - This could make Telegram Status show a stale/phantom A2S count while Telegram Players and TUI showed the corrected RCON roster count.
  - This keeps Telegram player counts consistent across bot views.

## Related issue

Closes #

## Validation

- [ ] `./scripts/run-host-tests`
- [ ] `python3 -m pytest -q`
- [ ] `python3 -m ruff check src tests`
- [ ] Relevant manual flow tested
- [ ] TUI flow tested, if this PR changes Textual screens or user interaction
- [x] The changed files are relevant to the linked issue
- [x] This PR does not introduce unrelated changes

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [ ] systemd / timer
- [ ] config.json handling
- [ ] Mods / addon cleanup
- [ ] TUI / UX / Textual screens
- [x] Telegram bot
- [ ] Release / versioning
- [ ] docs only

## Automated contribution disclosure

- [x] This PR was written or substantially reviewed by a human maintainer/contributor
- [x] This is not a low-effort automated bounty submission
- [x] If AI or automation was used, the generated changes were manually reviewed

## Notes

- No migration is required.
- No config changes are required.
- Rollback is safe: reverting this PR restores the previous Telegram Status snapshot behavior.
- Operator-facing implication:
  - Telegram Status and Telegram Players should now report the same player count when RCON roster data is available.
  - A2S remains fallback behavior through the shared player view.
- Manual Telegram flow to test:
  - Open the Telegram bot menu.
  - Check `Status`.
  - Open `Players`.
  - Confirm both views report the same player count.
- TUI flows are not changed by this PR.