### PR TITLE
Update GitHub Actions workflow for Pages deployment

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,42 @@
+name: Deploy website to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "website/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload website artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: website
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Added/updated the GitHub Pages workflow for deploying the static `website/` directory.
- Switched the Pages deployment to the static HTML GitHub Actions flow.
- Updated the Pages configuration step to use `actions/configure-pages@v6`.

This was needed because the previous Pages run failed during `Configure GitHub Pages` before deployment. The repository needs to deploy the static landing page from `website/` through GitHub Actions.

## Related issue

No linked issue.

## Validation

- [ ] `./scripts/run-host-tests`
- [ ] `python3 -m pytest -q`
- [ ] `python3 -m ruff check src tests`
- [x] Relevant manual flow tested
- [ ] TUI flow tested, if this PR changes Textual screens or user interaction
- [x] The changed files are relevant to the linked issue
- [x] This PR does not introduce unrelated changes

Manual validation performed:

- Verified the workflow deploys the `website/` directory as a static HTML site.
- Verified the Pages source is intended to use GitHub Actions.
- Verified this change does not touch runtime code, installer logic, TUI screens, Telegram bot code, or server management logic.

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [ ] systemd / timer
- [ ] config.json handling
- [ ] Mods / addon cleanup
- [ ] TUI / UX / Textual screens
- [ ] Telegram bot
- [ ] Release / versioning
- [x] docs only

## Automated contribution disclosure

- [x] This PR was written or substantially reviewed by a human maintainer/contributor
- [x] This is not a low-effort automated bounty submission
- [x] If AI or automation was used, the generated changes were manually reviewed

## Notes

- No migration is required.
- No rollback is required for existing installations.
- Operator-facing behavior is unchanged.
- This PR only affects static website deployment.
- After merge, GitHub Pages should publish the site at `https://dturovskiy.github.io/armactl/`.