### PR TITLE
Prepare v0.5.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ Semantic Versioning once public releases begin.
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-06-07
+
+### Added
+- Added regression coverage for large TUI mod lists and sidecar rollback behavior.
+- Added an audit fix plan documenting completed reliability and safety findings.
+
+### Changed
+- Changed TUI mod input handling to collect all valid 16-character Workshop IDs from pasted text in one flow.
+- Changed mod/admin metadata updates to roll back paired `config.json` and sidecar writes when one write fails.
+
+### Fixed
+- Fixed TUI bulk mod adding for large pasted mod lists without adding a mod-count limit.
+- Fixed unsafe instance names reaching data-root paths or systemd unit-name generation.
+- Fixed service generation continuing after a failed unit install.
+- Fixed Telegram bot `.env` file writes to use owner-only permissions.
+- Fixed addon cleanup path safety by skipping symlinks and revalidating paths before deletion.
+- Fixed backup filename collisions during rapid repeated config saves.
+
+### Validation
+- `./scripts/run-host-tests -- tests -q`
+- `python3 -m pytest -q` via `./scripts/run-host-tests` (`278 passed`)
+- `python3 -m ruff check src tests` via `./scripts/run-host-tests`
+
+### Operational notes
+- Existing installations do not need a migration.
+- No mod-count limit was added; operators can paste large mod lists into the TUI add-mod flow.
+- Bot `.env` files written by this release are created with `0600` permissions.
+
 ## [0.5.2] - 2026-05-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "armactl"
-version = "0.5.2"
+version = "0.5.3"
 description = "Installer, manager and TUI for Arma Reforger Dedicated Server on Linux"
 readme = "README.md"
 license = "MIT"

--- a/src/armactl/__init__.py
+++ b/src/armactl/__init__.py
@@ -1,3 +1,3 @@
 """armactl - installer, manager and TUI for Arma Reforger Dedicated Server."""
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"


### PR DESCRIPTION
## Summary

- Prepared the v0.5.3 patch release.
- Updated package metadata in `pyproject.toml` and `src/armactl/__init__.py`.
- Added concise operator-focused release notes to `CHANGELOG.md`.

This was needed to release the merged TUI bulk-mod add fix and the audit hardening changes from main.

## Related issue

N/A

## Validation

- [x] `./scripts/run-host-tests -- tests -q`
- [x] `python3 -m pytest -q` via `./scripts/run-host-tests` (`278 passed`)
- [x] `python3 -m ruff check src tests` via `./scripts/run-host-tests`
- [ ] Relevant manual flow tested
- [ ] TUI flow tested, if this PR changes Textual screens or user interaction
- [x] The changed files are relevant to the linked issue
- [x] This PR does not introduce unrelated changes

## Risk areas

- [ ] Install / bootstrap
- [ ] Existing server detection
- [ ] systemd / timer
- [ ] config.json handling
- [ ] Mods / addon cleanup
- [ ] TUI / UX / Textual screens
- [ ] Telegram bot
- [x] Release / versioning
- [ ] docs only

## Automated contribution disclosure

- [x] This PR was written or substantially reviewed by a human maintainer/contributor
- [x] This is not a low-effort automated bounty submission
- [x] If AI or automation was used, the generated changes were manually reviewed

## Notes

- Release PR intentionally changes only `pyproject.toml`, `src/armactl/__init__.py`, and `CHANGELOG.md`.
- Existing installations do not need a migration.
- No mod-count limit was added in the released changes.
- Local validation used `HOME=/var/tmp/armactl-release-home` because this SFTP/devbox environment has `.git` markers under `/home/devbox` and `/tmp`, which intentionally trigger install-dir safety checks.