### PR TITLE
Fix repair recovery and server telemetry status

### DIFF
--- a/src/armactl/integrity.py
+++ b/src/armactl/integrity.py
@@ -205,6 +205,7 @@ def _read_steam_complete(install_dir: Path) -> tuple[bool, bool | None]:
 def check_package_integrity(
     install_dir: Path,
     *,
+    ignore_install_marker: bool = False,
     verify_hashes: bool = False,
     report_limit: int = 25,
 ) -> PackageIntegrity:
@@ -228,7 +229,7 @@ def check_package_integrity(
         steam_complete=steam_complete,
     )
 
-    if marker_exists:
+    if marker_exists and not ignore_install_marker:
         base.status = "installing"
         return base
 

--- a/src/armactl/metrics.py
+++ b/src/armactl/metrics.py
@@ -76,7 +76,7 @@ FPS_STATS_RE = re.compile(
     r"FPS:\s*(?P<fps>\d+(?:\.\d+)?),\s*"
     r"frame time\s*\(\s*avg:\s*(?P<frame_avg>\d+(?:\.\d+)?)\s*ms,\s*"
     r"min:\s*(?P<frame_min>\d+(?:\.\d+)?)\s*ms,\s*"
-    r"max:\s*(?P<frame_max>\d+(?:\.\d+)?)\s*ms\s*\),\s*"
+    r"max:\s*(?P<frame_max>\d+(?:\.\d+)?)\s*ms(?:,\s*[^)]*)?\s*\),\s*"
     r"Mem:\s*(?P<memory_kb>\d+)\s*kB,\s*"
     r"Player:\s*(?P<players>\d+),\s*"
     r"AI:\s*(?P<ai>\d+),\s*"
@@ -253,7 +253,6 @@ def _line_has_download_retry(line: str) -> bool:
         for marker in (
             "Fragmentizer: Retrying download",
             "Fragmentizer: Download error",
-            "Curl error=",
         )
     )
 

--- a/src/armactl/paths.py
+++ b/src/armactl/paths.py
@@ -99,7 +99,8 @@ def validate_server_install_dir(
     """Validate that SteamCMD/server runtime files stay outside Git/source trees."""
     resolved = Path(install_dir).expanduser().resolve(strict=False)
     source_root = project_root().expanduser().resolve(strict=False)
-    expected = _server_dir_guidance(instance, data_root)
+    expected_path = server_dir(instance, data_root).expanduser().resolve(strict=False)
+    expected = str(expected_path)
 
     if resolved == source_root:
         raise UnsafeServerInstallDirError(
@@ -122,6 +123,8 @@ def validate_server_install_dir(
 
     git_marker = _containing_git_marker(resolved)
     if git_marker is not None:
+        if resolved == expected_path:
+            return resolved
         raise UnsafeServerInstallDirError(
             "Refusing to use a directory inside a Git working tree as the "
             f"Arma Reforger server install directory: {resolved} "

--- a/src/armactl/repair.py
+++ b/src/armactl/repair.py
@@ -16,8 +16,10 @@ from armactl.i18n import _, tr
 from armactl.installer import InstallError, stream_server_update
 from armactl.integrity import (
     IntegrityError,
+    PackageIntegrity,
     check_package_integrity,
     clear_install_marker,
+    install_marker_path,
     mark_install_started,
     write_package_manifest,
 )
@@ -31,6 +33,20 @@ from armactl.service_manager import (
 
 class RepairError(Exception):
     """Raised when repair fails fatally."""
+
+
+def _repair_failure_should_clear_marker(
+    previous_integrity: PackageIntegrity,
+    *,
+    config_path: Path,
+    had_install_marker: bool,
+) -> bool:
+    """Return whether a failed repair should remove the marker it set or found."""
+    if not had_install_marker:
+        return True
+    if previous_integrity.complete:
+        return True
+    return previous_integrity.status == "untracked" and config_path.is_file()
 
 
 def run_repair(
@@ -66,7 +82,11 @@ def run_repair(
         yield _("  - Server is already stopped")
 
     yield tr("[{instance}] Step 2: Validating game files via SteamCMD...", instance=instance)
-    previous_integrity = check_package_integrity(install_dir)
+    had_install_marker = install_marker_path(install_dir).is_file()
+    previous_integrity = check_package_integrity(
+        install_dir,
+        ignore_install_marker=had_install_marker,
+    )
     mark_install_started(install_dir)
     try:
         yield from stream_server_update(install_dir, instance=instance)
@@ -83,11 +103,19 @@ def run_repair(
         yield _("  OK Server files validated and updated")
         yield _("  OK Package integrity manifest refreshed")
     except InstallError as e:
-        if previous_integrity.complete:
+        if _repair_failure_should_clear_marker(
+            previous_integrity,
+            config_path=config_path,
+            had_install_marker=had_install_marker,
+        ):
             clear_install_marker(install_dir)
         raise RepairError(str(e)) from e
     except (IntegrityError, OSError) as e:
-        if previous_integrity.complete:
+        if _repair_failure_should_clear_marker(
+            previous_integrity,
+            config_path=config_path,
+            had_install_marker=had_install_marker,
+        ):
             clear_install_marker(install_dir)
         raise RepairError(
             tr("Failed to record package integrity manifest: {error}", error=e)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -14,6 +14,13 @@ SAMPLE_FPS_LINE = (
     "Player: 0, AI: 227, AIChar: 168, Veh: 0 (8), Proj "
     "(S: 0, M: 0, G: 0 | 0), Streaming(Dynam: 1433, Static: 29291)"
 )
+SAMPLE_FPS_LINE_WITH_MEAN_MEDIAN = (
+    "15:26:29.177   DEFAULT      : FPS: 60.0, frame time "
+    "(avg: 16.7 ms, min: 15.1 ms, max: 18.0 ms, mean: 16.7 ms, "
+    "median: 16.7 ms), Mem: 2571066 kB, Player: 0, AI: 232, "
+    "AIChar: 182, Veh: 0 (62), Proj (S: 0, M: 0, G: 0 | 0), "
+    "Streaming(Dynam: 1384, Static: 15780)"
+)
 
 
 def _write_console_log(
@@ -242,6 +249,30 @@ def test_query_server_fps_metrics_parses_valid_logstats_line(tmp_path: Path) -> 
     assert result.age_seconds == 8.0
 
 
+def test_query_server_fps_metrics_parses_current_logstats_line(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "config"
+    _write_console_log(
+        config_dir,
+        "2026-06-11_151427",
+        SAMPLE_FPS_LINE_WITH_MEAN_MEDIAN,
+        mtime=1000.0,
+    )
+
+    with patch("armactl.metrics.time.time", return_value=1008.0):
+        result = metrics.query_server_fps_metrics(config_dir)
+
+    assert result.available is True
+    assert result.fps == 60.0
+    assert result.frame_avg_ms == 16.7
+    assert result.frame_min_ms == 15.1
+    assert result.frame_max_ms == 18.0
+    assert result.engine_memory_kb == 2571066
+    assert result.ai == 232
+    assert result.ai_char == 182
+
+
 def test_query_server_fps_metrics_selects_latest_console_log_by_mtime(
     tmp_path: Path,
 ) -> None:
@@ -323,6 +354,8 @@ def test_query_server_fps_metrics_ignores_malformed_lines(tmp_path: Path) -> Non
 
     assert result.available is False
     assert result.error == "server FPS telemetry line is not available"
+
+
 def test_query_server_operational_status_reports_mod_download_retry(
     tmp_path: Path,
 ) -> None:
@@ -394,4 +427,55 @@ def test_query_server_operational_status_reports_ready_from_fps(
     assert result.available is True
     assert result.state == "ready"
     assert result.severity == "success"
+    assert result.message == "Ready"
+
+
+def test_query_server_operational_status_reports_ready_when_rcon_noise_is_latest(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "config"
+    _write_console_log(
+        config_dir,
+        "2026-06-11_151427",
+        "\n".join(
+            [
+                SAMPLE_FPS_LINE_WITH_MEAN_MEDIAN,
+                "15:26:31.433 BACKEND : [RCON] 127.0.0.1:58126 Authorized as Client #0",
+                "15:26:34.689 BACKEND : [RCON] Client 0 logged out!",
+            ]
+        ),
+        mtime=1000.0,
+    )
+
+    with patch("armactl.metrics.time.time", return_value=1005.0):
+        result = metrics.query_server_operational_status(config_dir)
+
+    assert result.available is True
+    assert result.state == "ready"
+    assert result.severity == "success"
+    assert result.message == "Ready"
+
+
+def test_query_server_operational_status_ignores_backend_heartbeat_timeout(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "config"
+    _write_console_log(
+        config_dir,
+        "2026-06-11_151427",
+        "\n".join(
+            [
+                SAMPLE_FPS_LINE_WITH_MEAN_MEDIAN,
+                "15:26:04.972 BACKEND   (E): Curl error=Timeout was reached",
+                "15:26:04.996 BACKEND   (E): DS Room Heartbeat fail, Timeout to recover=300 sec",
+            ]
+        ),
+        mtime=1000.0,
+    )
+
+    with patch("armactl.metrics.time.time", return_value=1005.0):
+        result = metrics.query_server_operational_status(config_dir)
+
+    assert result.available is True
+    assert result.state == "ready"
     assert result.message == "Ready"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -20,6 +20,7 @@ from armactl.paths import (
     start_script,
     state_file,
     validate_instance_name,
+    validate_server_install_dir,
 )
 
 
@@ -130,3 +131,20 @@ def test_privileged_sudoers_file():
 
 def test_privileged_helper_and_sudoers_paths_are_distinct():
     assert privileged_helper_file() != privileged_sudoers_file()
+
+
+def test_validate_server_install_dir_allows_expected_instance_dir_under_git_home(
+    tmp_path,
+    monkeypatch,
+):
+    data_root = tmp_path / "armactl-data"
+    install_dir = data_root / "default" / "server"
+    git_marker = tmp_path / ".git"
+    git_marker.mkdir()
+
+    monkeypatch.setattr(
+        "armactl.paths._containing_git_marker",
+        lambda path: git_marker,
+    )
+
+    assert validate_server_install_dir(install_dir, data_root=data_root) == install_dir

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -7,7 +7,13 @@ import pytest
 
 import armactl.i18n as i18n
 import armactl.service_manager as service_manager
-from armactl.integrity import check_package_integrity
+from armactl.installer import InstallError
+from armactl.integrity import (
+    check_package_integrity,
+    install_marker_path,
+    mark_install_started,
+    write_package_manifest,
+)
 from armactl.repair import RepairError, run_repair
 from armactl.state import ServerState
 
@@ -67,3 +73,69 @@ def test_run_repair_refuses_project_root_install_dir(tmp_path: Path) -> None:
 
     with pytest.raises(RepairError, match="project root"):
         list(run_repair("default", repo_root, config_path))
+
+
+def test_run_repair_clears_new_install_marker_after_steamcmd_failure(
+    tmp_path: Path,
+) -> None:
+    instance_root = tmp_path / "default"
+    server_dir = instance_root / "server"
+    config_path = instance_root / "config" / "config.json"
+    server_dir.mkdir(parents=True)
+    config_path.parent.mkdir(parents=True)
+    (server_dir / "ArmaReforgerServer").write_text("fake binary", encoding="utf-8")
+    config_path.write_text("{}", encoding="utf-8")
+
+    state = ServerState(
+        server_running=False,
+        service_name="armareforger.service",
+        install_dir=str(server_dir),
+        config_path=str(config_path),
+    )
+
+    with (
+        patch("armactl.repair.paths._containing_git_marker", return_value=None),
+        patch("armactl.repair.discover_manual", return_value=state),
+        patch(
+            "armactl.repair.stream_server_update",
+            side_effect=InstallError("SteamCMD failed"),
+        ),
+    ):
+        with pytest.raises(RepairError, match="SteamCMD failed"):
+            list(run_repair("default", server_dir, config_path))
+
+    assert not install_marker_path(server_dir).exists()
+
+
+def test_run_repair_clears_stale_marker_for_previous_complete_install(
+    tmp_path: Path,
+) -> None:
+    instance_root = tmp_path / "default"
+    server_dir = instance_root / "server"
+    config_path = instance_root / "config" / "config.json"
+    server_dir.mkdir(parents=True)
+    config_path.parent.mkdir(parents=True)
+    (server_dir / "ArmaReforgerServer").write_text("fake binary", encoding="utf-8")
+    config_path.write_text("{}", encoding="utf-8")
+    write_package_manifest(server_dir)
+    mark_install_started(server_dir)
+
+    state = ServerState(
+        server_running=False,
+        service_name="armareforger.service",
+        install_dir=str(server_dir),
+        config_path=str(config_path),
+    )
+
+    with (
+        patch("armactl.repair.paths._containing_git_marker", return_value=None),
+        patch("armactl.repair.discover_manual", return_value=state),
+        patch(
+            "armactl.repair.stream_server_update",
+            side_effect=InstallError("SteamCMD failed"),
+        ),
+    ):
+        with pytest.raises(RepairError, match="SteamCMD failed"):
+            list(run_repair("default", server_dir, config_path))
+
+    assert not install_marker_path(server_dir).exists()


### PR DESCRIPTION
## Summary

  - Fixed repair marker cleanup so failed repair attempts do not leave healthy installs
  stuck as `installing`.
  - Allowed the expected `~/armactl-data/<instance>/server` install path even when a
  parent directory has a `.git` marker.
  - Updated FPS telemetry parsing for current Arma Reforger log format with `mean` /
  `median`.
  - Prevented generic backend `Curl error=` heartbeat timeouts from being misreported as
  mod downloads.

  ## Related issue

  Closes #

  ## Validation

  - [ ] `./scripts/run-host-tests`
  - [x] `python3 -m pytest -q`
  - [ ] `python3 -m ruff check src tests`
  - [x] Relevant manual flow tested
  - [ ] TUI flow tested, if this PR changes Textual screens or user interaction
  - [x] The changed files are relevant to the linked issue
  - [x] This PR does not introduce unrelated changes

  ## Risk areas

  - [x] Install / bootstrap
  - [x] Existing server detection
  - [ ] systemd / timer
  - [ ] config.json handling
  - [x] Mods / addon cleanup
  - [x] TUI / UX / Textual screens
  - [ ] Telegram bot
  - [ ] Release / versioning
  - [ ] docs only

  ## Automated contribution disclosure

  - [ ] This PR was written or substantially reviewed by a human maintainer/contributor
  - [x] This is not a low-effort automated bounty submission
  - [x] If AI or automation was used, the generated changes were manually reviewed

  ## Notes

  - Operator-facing impact: existing healthy installs should no longer remain blocked by
  stale `.armactl-installing` markers after a failed repair.
  - Server status should now report `Ready` when fresh FPS telemetry is present, even if
  recent log lines contain RCON roster polling.
  - Generic backend heartbeat timeouts are no longer shown as “Downloading mods”.
  - Manual validation used live server logs from `armactl-data/default/config/logs`;
  telemetry reported `fps=60.0` and `status=ready`.
  - `./scripts/run-host-tests` was not run because the local wrapper environment
  attempted bootstrap through blocked `sudo`; pytest was run directly with the available
  Python path.
